### PR TITLE
Fixed issue with m

### DIFF
--- a/R/shapley.R
+++ b/R/shapley.R
@@ -90,7 +90,7 @@ get_combinations <- function(m, exact = TRUE, nrows = 200) {
 #' @export
 #'
 #' @author Nikolai Sellereite
-get_weights <- function(X) {
+get_weights <- function(X, m) {
     X[-c(1, .N), weight := w_shapley(m = m, N = N, s = nfeatures), ID]
     X[c(1, .N), weight := 10 ^ 6]
 
@@ -414,7 +414,7 @@ prepare_kernelShap <- function(m,
     X <- get_combinations(m = m, exact = exact, nrows = nrows)
 
     ## Add weights ----------------
-    X <- get_weights(X = X)
+    X <- get_weights(X = X, m = m)
 
     ## Get weighted matrix ----------------
     W <- get_weighted_matrix(X)


### PR DESCRIPTION
Fixes #4. 

One example to illustrate scoping in R: 

```
rm(list = ls())

f <- function() x + 1

h <- function(x) f()

x <- 1

h(2)
# [1] 2
```
In this snippet the scoping for `x` is done in the global environment since that is where `f` is defined. So when calling `f` inside `h` gives `1 + 1` instead of `2 + 1`.   


```
rm(list = ls())

h <- function(x) {
    f <- function() x + 1

    f()
}

x <- 1

h(2)
# [1] 3 
```
In this snippet the scoping for `x` is done inside `h` since that is where `f` is defined. So when calling `f` inside `h` gives `2 + 1` instead of `1 + 1`.

Anyways, the changes should take care of this bug. Another solution could be to define `get_weights` inside `prepare_kernelShap`.