### PR TITLE
Adds URL to DESCRIPTION, and adds a description of the package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,13 @@
 Package: shapr
 Version: 0.0.0.9000
-Title: Explain the output of machine learning models with accurately estimated Shapley values 
-Description: Complex machine learning models are often hard to interpret. However, in many situations it is crucial to understand and explain why a model made a specific prediction. Shapley values is the only method for such prediction explanation framework with a solid theoretical foundation. Previously known methods for estimating the Shapley values do, however, assume feature independence. This package implements the method described in Aas, Jullum and Løland (2019) <arXiv:1903.10464>, which accounts for any feature dependence, and thereby produces more accuracte estimates of the Shapley values.
+Title: Explain the output of machine learning models with more accurately estimated Shapley values 
+Description: Complex machine learning models are often hard to interpret. However, in 
+  many situations it is crucial to understand and explain why a model made a specific 
+  prediction. Shapley values is the only method for such prediction explanation framework 
+  with a solid theoretical foundation. Previously known methods for estimating the Shapley 
+  values do, however, assume feature independence. This package implements the method 
+  described in Aas, Jullum and Løland (2019) <arXiv:1903.10464>, which accounts for any feature 
+  dependence, and thereby produces more accuracte estimates of the true Shapley values.
 Authors@R: c(
     person("Nikolai", "Sellereite", email = "Nikolai.Sellereite@nr.no", role = "cre"),
     person("Martin", "Jullum", email = "Martin.Jullum@nr.no", role = "aut"),  


### PR DESCRIPTION
@martinju Could you update the following in `DESCRIPTION:
```
Description: What the package does (one paragraph).
```

Thanks! Should only be a paragraph. Note that you could also update the title of the package if you don't like it. 

Fixes https://github.com/NorskRegnesentral/shapr/issues/23. 