### PR TITLE
Runs example every time you re-knit README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -73,7 +73,7 @@ devtools::install_github("NorskRegnesentral/shapr")
 The following example shows how a simple `xgboost` model is trained using the *Boston Housing Data*, and how `shapr` explains the individual predictions. 
 
 
-```r
+```{r}
 library(MASS)
 library(xgboost)
 library(shapr)
@@ -88,13 +88,7 @@ y_train <- Boston[-(1:10), y_var]
 x_test <- as.matrix(Boston[1:10, x_var])
 
 # Quick look at the dependence between the features
- cor(x_train)
- #> cor(x_train)
- # lstat         rm        dis      indus
- # lstat  1.0000000 -0.6106362 -0.5075796  0.6073291
- # rm    -0.6106362  1.0000000  0.2051866 -0.3897134
- # dis   -0.5075796  0.2051866  1.0000000 -0.7059103
- # indus  0.6073291 -0.3897134 -0.7059103  1.0000000
+cor(x_train)
 
 # The features are are highly correlated
 
@@ -102,7 +96,8 @@ x_test <- as.matrix(Boston[1:10, x_var])
 model <- xgboost(
   data = x_train, 
   label = y_train, 
-  nround = 20
+  nround = 20, 
+  verbose = FALSE
 )
 
 # Prepare the data for explanation
@@ -113,6 +108,7 @@ l <- prepare_kshap(
 
 # Specifying the phi_0, i.e. the expected prediction without any features
 pred_zero <- mean(y_train)
+print(pred_zero)
 
 # Computing the actual Shapley values with kernelSHAP accounting for feature dependence using
 # the empirical (conditional) distribution approach with bandwidth parameter sigma = 0.1 (default)
@@ -123,15 +119,7 @@ explanation <- compute_kshap(
 )
 
 # Printing the Shapley values for the test data
-explanation$Kshap
-
-#          [,1]      [,2]       [,3]        [,4]       [,5]
-# [1,] 22.45484 5.3814963 -0.4823530  1.56978008  4.9216356
-# [2,] 22.45484 0.3344492 -0.8322893  0.97687526  0.3750935
-# [3,] 22.45484 6.1609843  4.8894905  0.53138409 -2.0826502
-# [4,] 22.45484 8.9163071  0.3154509 -0.18616672  2.1797222
-# [5,] 22.45484 0.7486236  6.2298609  0.24828116  2.7369589
-# [6,] 22.45484 2.5868833 -3.8420937 -0.02532364  3.1038779
+print(explanation$Kshap)
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -71,13 +71,12 @@ y_train <- Boston[-(1:10), y_var]
 x_test <- as.matrix(Boston[1:10, x_var])
 
 # Quick look at the dependence between the features
- cor(x_train)
- #> cor(x_train)
- # lstat         rm        dis      indus
- # lstat  1.0000000 -0.6106362 -0.5075796  0.6073291
- # rm    -0.6106362  1.0000000  0.2051866 -0.3897134
- # dis   -0.5075796  0.2051866  1.0000000 -0.7059103
- # indus  0.6073291 -0.3897134 -0.7059103  1.0000000
+cor(x_train)
+#>            lstat         rm        dis      indus
+#> lstat  1.0000000 -0.6106362 -0.5075796  0.6073291
+#> rm    -0.6106362  1.0000000  0.2051866 -0.3897134
+#> dis   -0.5075796  0.2051866  1.0000000 -0.7059103
+#> indus  0.6073291 -0.3897134 -0.7059103  1.0000000
 
 # The features are are highly correlated
 
@@ -85,7 +84,8 @@ x_test <- as.matrix(Boston[1:10, x_var])
 model <- xgboost(
   data = x_train, 
   label = y_train, 
-  nround = 20
+  nround = 20, 
+  verbose = FALSE
 )
 
 # Prepare the data for explanation
@@ -96,6 +96,8 @@ l <- prepare_kshap(
 
 # Specifying the phi_0, i.e. the expected prediction without any features
 pred_zero <- mean(y_train)
+print(pred_zero)
+#> [1] 22.45484
 
 # Computing the actual Shapley values with kernelSHAP accounting for feature dependence using
 # the empirical (conditional) distribution approach with bandwidth parameter sigma = 0.1 (default)
@@ -106,15 +108,18 @@ explanation <- compute_kshap(
 )
 
 # Printing the Shapley values for the test data
-explanation$Kshap
-
-#          [,1]      [,2]       [,3]        [,4]       [,5]
-# [1,] 22.45484 5.3814963 -0.4823530  1.56978008  4.9216356
-# [2,] 22.45484 0.3344492 -0.8322893  0.97687526  0.3750935
-# [3,] 22.45484 6.1609843  4.8894905  0.53138409 -2.0826502
-# [4,] 22.45484 8.9163071  0.3154509 -0.18616672  2.1797222
-# [5,] 22.45484 0.7486236  6.2298609  0.24828116  2.7369589
-# [6,] 22.45484 2.5868833 -3.8420937 -0.02532364  3.1038779
+print(explanation$Kshap)
+#>           [,1]       [,2]       [,3]        [,4]        [,5]
+#>  [1,] 22.45484  5.3814963 -0.4823530  1.56978008  4.92163556
+#>  [2,] 22.45484  0.3344492 -0.8322893  0.97687526  0.37509350
+#>  [3,] 22.45484  6.1609843  4.8894905  0.53138409 -2.08265017
+#>  [4,] 22.45484  8.9163071  0.3154509 -0.18616672  2.17972216
+#>  [5,] 22.45484  0.7486236  6.2298609  0.24828117  2.73695892
+#>  [6,] 22.45484  2.5868833 -3.8420937 -0.02532364  3.10387793
+#>  [7,] 22.45484 -1.0434064 -1.5499314  1.19064778 -0.83828715
+#>  [8,] 22.45484 -5.3505414 -0.4604888  1.34558699 -0.52891751
+#>  [9,] 22.45484 -6.0891236 -1.1543907  1.57635992  0.02279797
+#> [10,] 22.45484 -4.0430392 -1.2308774  0.55839033 -0.78247565
 ```
 
 References


### PR DESCRIPTION
The previous version contained copied output from the code. Removed this part in `README.Rmd` and adjusted the script so that the code is actually run every time you re-knit `README.Rmd`. The output from print commands is then present in `README.md`, which is the file presented on Github. 

Note that this will also behave a check that potential code changes doesn't affect the numeric output of the routines.    