### PR TITLE
Fixes length of lines

### DIFF
--- a/R/extra.R
+++ b/R/extra.R
@@ -1,10 +1,11 @@
-#' Helper function to sample a combination of training and testing rows, which does not risk getting the same observation twice.
-#' Need to improve this help file.
+#' Helper function to sample a combination of training and testing rows, which does not risk
+#' getting the same observation twice. Need to improve this help file.
 #'
 #' @inheritParams global_arguments
-#' @param separate Logical indicating whether the train and test data should be sampled separately or in a joint sampling space.
-#' If they are sampled separately (which typically would be used when optimizing more than one distribution at once) we sample with
-#' replacement if more samples than training data. Not optimal, but for now fine if careful when using more samples than the number
+#' @param separate Logical indicating whether the train and test data should be sampled separately
+#' or in a joint sampling space. If they are sampled separately (which typically would be used when
+#' optimizing more than one distribution at once) we sample with replacement if more samples than
+#' training data. Not optimal, but for now fine if careful when using more samples than the number
 #' training observations while at the same time doing optimization over every test observation.
 #'
 #' @return Numeric
@@ -13,10 +14,12 @@
 #'
 #' @author Martin Jullum
 sample_combinations <- function(nTrain, nTest, nosamp, separate = F) {
-  if (separate) { # With separate sampling, we do sampling with replacement if nosamp is larger than nTrain
+  if (separate) {
+    # With separate sampling, we do sampling with replacement if nosamp is larger than nTrain
     sampinds_train <- 1:nTrain
     sampinds_test <- 1:nTest
-    if (nosamp < nTrain) { # Not optimal in general, but works for the current purpose. test data is always sampled,
+    if (nosamp < nTrain) {
+      # Not optimal in general, but works for the current purpose. test data is always sampled,
       # while only reducing if the training data goes above nosamp.
       samp_train <- sample(
         x = sampinds_train,

--- a/R/global.R
+++ b/R/global.R
@@ -1,22 +1,30 @@
 #' Set of global arguments used in the package
 #'
 #' @param Xtrain Matrix, data.frame or data.table with the features from the training data
-#' @param Xtest Matrix, data.frame or data.table with the features, whose predictions ought to be explained (test data)
+#' @param Xtest Matrix, data.frame or data.table with the features, whose predictions ought to
+#' be explained (test data)
 #' @param Xtrain_mat Matrix with the features from the training data
 #' @param Xtest_mat Matrix with the features, whose predictions ought to be explained (test data)
-#' @param exact Logical. If TRUE, uses the full sum in the Shapley formula, if FALSE, uses a sampling approach to approximate the sum
+#' @param exact Logical. If TRUE, uses the full sum in the Shapley formula, if FALSE, uses a
+#' sampling approach to approximate the sum
 #' @param noSamp Integer. How many samples to use when approximating the sum in the Shapley formula
 #' (previously called \code{nrows})
-#' @param shapley_weight_inf_replacement Numeric. Indicating which weight to use for the full conditional and unconditional expectations in kernel SHAPs weighted least squares formulation.
-#' @param reduce_dim Logical. Indicating whether to reduce the dimension of the weighted least squares problem by merging identical columns and adjusting their weights.
+#' @param shapley_weight_inf_replacement Numeric. Indicating which weight to use for the full
+#' conditional and unconditional expectations in kernel SHAPs weighted least squares formulation.
+#' @param reduce_dim Logical. Indicating whether to reduce the dimension of the weighted least
+#' squares problem by merging identical columns and adjusting their weights.
 #' @param m Integer. Total number of features
 #' @param model Model object. Fitted model that is used to produce the predictions
 #' @param l List. The output from the \code{prepare_kshap} function
-#' @param noSamp_MC Positive integer. Indicating the maximum number of samples to use in the Monte Carlo integration for every conditional expectation (previously called \code{n_threshold})
+#' @param noSamp_MC Positive integer. Indicating the maximum number of samples to use in the
+#' Monte Carlo integration for every conditional expectation (previously called \code{n_threshold})
 #' @param verbose Integer. How much information to print during function execution (in development)
-#' @param cond_approach String or list. When being a list, the elements in the list refers to the rows in l$X that ought to be included in each of the approaches!
-#' @param mu Numeric vector. (Optional) Containing the mean of the data generating distribution. NULL means it is estimated from the data if needed (in the Gaussian approach).
-#' @param Sigma Numeric matrix. (Optional) Containing the covariance matrix of the data generating distribution. NULL means it is estimated from the data if needed (in the Gaussian approach).
+#' @param cond_approach String or list. When being a list, the elements in the list refers to the
+#' rows in l$X that ought to be included in each of the approaches!
+#' @param mu Numeric vector. (Optional) Containing the mean of the data generating distribution.
+#' NULL means it is estimated from the data if needed (in the Gaussian approach).
+#' @param Sigma Numeric matrix. (Optional) Containing the covariance matrix of the data generating
+#' distribution. NULL means it is estimated from the data if needed (in the Gaussian approach).
 #' @param N Integer. Number of combinations
 #' @param s Integer. Number of chosen
 #' @param nsamples Integer. Number of samples
@@ -29,18 +37,23 @@
 #' @param S Matrix
 #' @param verbose Logical
 #' @param scale Logical
-#' @param cond_approach Either a string indicating which method should be used to estimate all conditional expectations.
-#' Defaults to "empirical_fixed_sigma", with "empirical_AICc_full", "empirical_AICc_each_k","Gaussian" and "copula" being other alternatives. One can also supply a named list where the names
-#' are one or more of the implemented methods, and the named lists contains one vector each, each containing the row numbers of the S-matrix
-#' computed using \code{prepare_kshap} that whose corresponding conditional expectations should be computed with that method. Any number not
-#' specified is computed with the default empirical method.
-#' @param distance_metric String indicating which distance metric should be used in the empirical conditional
-#' distribution. Defaults to "Euclidean", "Mahalanobis" and "Mahalanobis_scaled" being the other options. "Mahalanobis_scaled" includes
-#' the 1/|S| factor in the paper is preferred for a consistent \eqn{\sigma}.
-#' @param kernel_metric String indicating which kernel metric should be used in the empirical conditional distribution.
-#' Defaults to "Gaussian" [\eqn{\exp(-D/2\sigma)}], with "independence" (imputing independently, ignoring any distance) being the second option
-#' "Gaussian_old" [\eqn{\sqrt(\exp(-D/2\sigma))}] is also kept for reproducibility.
-#' @param W_kernel Array. Contains all nonscaled weights between training and testing observations for all combinations.
+#' @param cond_approach Either a string indicating which method should be used to estimate all
+#' conditional expectations. Defaults to "empirical_fixed_sigma", with "empirical_AICc_full",
+#' "empirical_AICc_each_k","Gaussian" and "copula" being other alternatives. One can also supply a
+#' named list where the names are one or more of the implemented methods, and the named lists
+#' contains one vector each, each containing the row numbers of the S-matrix computed using
+#' \code{prepare_kshap} that whose corresponding conditional expectations should be computed with
+#' that method. Any number not specified is computed with the default empirical method.
+#' @param distance_metric String indicating which distance metric should be used in the empirical
+#' conditional distribution. Defaults to "Euclidean", "Mahalanobis" and "Mahalanobis_scaled" being
+#' the other options. "Mahalanobis_scaled" includes the 1/|S| factor in the paper is preferred for
+#' a consistent \eqn{\sigma}.
+#' @param kernel_metric String indicating which kernel metric should be used in the empirical
+#' conditional distribution. Defaults to "Gaussian" [\eqn{\exp(-D/2\sigma)}], with "independence"
+#' (imputing independently, ignoring any distance) being the second option "Gaussian_old"
+#' [\eqn{\sqrt(\exp(-D/2\sigma))}] is also kept for reproducibility.
+#' @param W_kernel Array. Contains all nonscaled weights between training and testing observations
+#' for all combinations.
 #' @param Xtest_Gauss_trans Vector with the Gaussian transformed test observations
 #' @param mu Mean vector of training set
 #' @param Sigma Covariance matrix of training set

--- a/R/groupVariables.R
+++ b/R/groupVariables.R
@@ -97,8 +97,8 @@ correlation_rectangles <- function(
   clustab <- table(hc)[unique(hc[cluster$order])]
   cu <- c(0, cumsum(clustab))
 
-  rect(cu[-(k + 1)] + 0.5,
-    n - cu[-(k + 1)] + 0.5,
+  rect(cu[-1 * (k + 1)] + 0.5,
+    n - cu[-1 * (k + 1)] + 0.5,
     cu[-1] + 0.5,
     n - cu[-1] + 0.5,
     border = col, lwd = lwd

--- a/R/groupVariables.R
+++ b/R/groupVariables.R
@@ -97,8 +97,9 @@ correlation_rectangles <- function(
   clustab <- table(hc)[unique(hc[cluster$order])]
   cu <- c(0, cumsum(clustab))
 
-  rect(cu[-1 * (k + 1)] + 0.5,
-    n - cu[-1 * (k + 1)] + 0.5,
+  ind <- k + 1
+  rect(cu[-ind] + 0.5,
+    n - cu[-ind] + 0.5,
     cu[-1] + 0.5,
     n - cu[-1] + 0.5,
     border = col, lwd = lwd

--- a/R/plot.R
+++ b/R/plot.R
@@ -64,7 +64,12 @@ plot_kshap <- function(explanation,
     ggplot2::geom_col(ggplot2::aes(x = description, y = phi, fill = sign)) +
     ggplot2::coord_flip() +
     ggplot2::scale_fill_manual(values = c("steelblue", "lightsteelblue"), drop = TRUE) +
-    ggplot2::labs(y = "Feature contribution", x = "Feature", fill = "", title = "Shapley value prediction explanation") +
+    ggplot2::labs(
+      y = "Feature contribution",
+      x = "Feature",
+      fill = "",
+      title = "Shapley value prediction explanation"
+    ) +
     ggplot2::theme(
       legend.position = "bottom",
       plot.title = ggplot2::element_text(hjust = 0.5)

--- a/R/shapley.R
+++ b/R/shapley.R
@@ -818,7 +818,8 @@ compute_kshap <- function(model,
 
   # Only needed for copula method, but is not time consuming anyway
   Xtrain_Gauss_trans <- apply(X = l$Xtrain, MARGIN = 2, FUN = gaussian_transform)
-  Xtest_Gauss_trans <- apply(rbind(l$Xtest, l$Xtrain),
+  Xtest_Gauss_trans <- apply(
+    X = rbind(l$Xtest, l$Xtrain),
     MARGIN = 2,
     FUN = gaussian_transform_separate,
     n_y = nrow(l$Xtest)

--- a/inst/scripts/readme_example.R
+++ b/inst/scripts/readme_example.R
@@ -9,9 +9,9 @@ data("Boston")
 x_var <- c("lstat", "rm", "dis", "indus")
 y_var <- "medv"
 
-x_train <- as.matrix(Boston[-(1:6), x_var])
-y_train <- Boston[-(1:6), y_var]
-x_test <- as.matrix(Boston[1:6, x_var])
+x_train <- as.matrix(tail(Boston[, x_var], -6))
+y_train <- tail(Boston[, y_var], -6)
+x_test <- as.matrix(head(Boston[, x_var], 6))
 
 # Just looking at the dependence between the features
 


### PR DESCRIPTION
Ran `lintr::lint_package()` and fixed the following 
- Fixed issue with length of lines in code (should strive to keep the length at maximum 100)
- Moved comments that came after a closing/opening bracket
- Removed stale code that were commented out
- If there were comments after a specific input when defining a function I moved this into the documentation  

Note that there almost zero changes to code.