### PR TITLE
Changes variable names in sample_combinations()

### DIFF
--- a/R/extra.R
+++ b/R/extra.R
@@ -9,20 +9,21 @@
 #'
 #' @param nsamples Positive integer. Number of samples.
 #'
-#' @param separate Logical indicating whether the train and test data should be sampled separately
-#' or in a joint sampling space. If they are sampled separately (which typically would be used when
-#' optimizing more than one distribution at once) we sample with replacement if more samples than
-#' training data. Not optimal, but for now fine if careful when using more samples than the number
-#' training observations while at the same time doing optimization over every test observation.
+#' @param joint_sampling Logical. Indicates whether train- and test data should be sampled
+#' separately or in a joint sampling space. If they are sampled separately (which typically
+#' would be used when optimizing more than one distribution at once) we sample with replacement
+#' if \code{nsamples > ntrain}. Note that this solution is not optimal. Be careful if you're
+#' doing an optimization over every test observation.when \code{nsamples > ntrain}.
+#'
 #'
 #' @return Data.frame. Contains \code{nsamples} rows of re-sampled train and test observations.
 #'
 #' @export
 #'
 #' @author Martin Jullum
-sample_combinations <- function(ntrain, ntest, nsamples, separate = FALSE) {
+sample_combinations <- function(ntrain, ntest, nsamples, joint_sampling = TRUE) {
 
-  if (separate) {
+  if (!joint_sampling) {
 
     # Sample training data
     samp_train <- sample(

--- a/R/extra.R
+++ b/R/extra.R
@@ -13,7 +13,7 @@
 #' separately or in a joint sampling space. If they are sampled separately (which typically
 #' would be used when optimizing more than one distribution at once) we sample with replacement
 #' if \code{nsamples > ntrain}. Note that this solution is not optimal. Be careful if you're
-#' doing an optimization over every test observation when \code{nsamples > ntrain}.
+#' doing optimization over every test observation when \code{nsamples > ntrain}.
 #'
 #'
 #' @return Data.frame. Contains \code{nsamples} rows of re-sampled train and test observations.

--- a/R/extra.R
+++ b/R/extra.R
@@ -3,11 +3,11 @@
 #'
 #' @inheritParams global_arguments
 #'
-#' @param nTrain Positive integer. Number of training observations to sample from.
+#' @param ntrain Positive integer. Number of training observations to sample from.
 #'
-#' @param nTest Positive integer. Number of test observations to sample from.
+#' @param ntest Positive integer. Number of test observations to sample from.
 #'
-#' @param nosamp Positive integer. Number of samples.
+#' @param nsamples Positive integer. Number of samples.
 #'
 #' @param separate Logical indicating whether the train and test data should be sampled separately
 #' or in a joint sampling space. If they are sampled separately (which typically would be used when
@@ -15,43 +15,43 @@
 #' training data. Not optimal, but for now fine if careful when using more samples than the number
 #' training observations while at the same time doing optimization over every test observation.
 #'
-#' @return Data.frame. Contains \code{nosamp} rows of re-sampled train and test observations.
+#' @return Data.frame. Contains \code{nsamples} rows of re-sampled train and test observations.
 #'
 #' @export
 #'
 #' @author Martin Jullum
-sample_combinations <- function(nTrain, nTest, nosamp, separate = FALSE) {
+sample_combinations <- function(ntrain, ntest, nsamples, separate = FALSE) {
 
   if (separate) {
 
     # Sample training data
     samp_train <- sample(
-      x = nTrain,
-      size = nosamp,
-      replace = ifelse(nosamp < nTrain, FALSE, TRUE)
+      x = ntrain,
+      size = nsamples,
+      replace = ifelse(nsamples < ntrain, FALSE, TRUE)
     )
 
     # Sample test data
     samp_test <- sample(
-      x = nTest,
-      size = nosamp,
-      replace = ifelse(nosamp < nTrain, nosamp > nTest, TRUE)
+      x = ntest,
+      size = nsamples,
+      replace = ifelse(nsamples < ntrain, nsamples > ntest, TRUE)
     )
   } else {
 
-    n <- nTrain * nTest
-    if (nosamp < n) {
+    n <- ntrain * ntest
+    if (nsamples < n) {
       input_samp <- sample(
         x = n,
-        size = nosamp,
+        size = nsamples,
         replace = FALSE
       )
     } else {
       input_samp <- seq(n)
     }
 
-    samp_train <- (input_samp - 1) %% nTrain + 1
-    samp_test <- (input_samp - 1) %/% nTrain + 1
+    samp_train <- (input_samp - 1) %% ntrain + 1
+    samp_test <- (input_samp - 1) %/% ntrain + 1
   }
   ret <- data.frame(samp_train = samp_train, samp_test = samp_test)
 

--- a/R/extra.R
+++ b/R/extra.R
@@ -13,7 +13,7 @@
 #' separately or in a joint sampling space. If they are sampled separately (which typically
 #' would be used when optimizing more than one distribution at once) we sample with replacement
 #' if \code{nsamples > ntrain}. Note that this solution is not optimal. Be careful if you're
-#' doing an optimization over every test observation.when \code{nsamples > ntrain}.
+#' doing an optimization over every test observation when \code{nsamples > ntrain}.
 #'
 #'
 #' @return Data.frame. Contains \code{nsamples} rows of re-sampled train and test observations.

--- a/R/shapley.R
+++ b/R/shapley.R
@@ -148,7 +148,7 @@ compute_kshap <- function(model,
           ntrain = nrow(l$Xtrain),
           ntest = nrow(l$Xtest),
           nsamples = empirical_settings$AICc_no_samp_per_optim,
-          separate = T
+          joint_sampling = FALSE
         )
 
         # Updating parameter (only if it is larger than nTrain*nTest)

--- a/R/shapley.R
+++ b/R/shapley.R
@@ -145,9 +145,9 @@ compute_kshap <- function(model,
 
         # Procedure for sampling a combination of an index in the training and the test sets
         optimsamp <- sample_combinations(
-          nTrain = nrow(l$Xtrain),
-          nTest = nrow(l$Xtest),
-          nosamp = empirical_settings$AICc_no_samp_per_optim,
+          ntrain = nrow(l$Xtrain),
+          ntest = nrow(l$Xtest),
+          nsamples = empirical_settings$AICc_no_samp_per_optim,
           separate = T
         )
 

--- a/man/sample_combinations.Rd
+++ b/man/sample_combinations.Rd
@@ -18,7 +18,7 @@ sample_combinations(ntrain, ntest, nsamples, joint_sampling = TRUE)
 separately or in a joint sampling space. If they are sampled separately (which typically
 would be used when optimizing more than one distribution at once) we sample with replacement
 if \code{nsamples > ntrain}. Note that this solution is not optimal. Be careful if you're
-doing an optimization over every test observation.when \code{nsamples > ntrain}.}
+doing an optimization over every test observation when \code{nsamples > ntrain}.}
 }
 \value{
 Data.frame. Contains \code{nsamples} rows of re-sampled train and test observations.

--- a/man/sample_combinations.Rd
+++ b/man/sample_combinations.Rd
@@ -5,14 +5,14 @@
 \title{Helper function to sample a combination of training and testing rows, which does not risk
 getting the same observation twice. Need to improve this help file.}
 \usage{
-sample_combinations(nTrain, nTest, nosamp, separate = FALSE)
+sample_combinations(ntrain, ntest, nsamples, separate = FALSE)
 }
 \arguments{
-\item{nTrain}{Positive integer. Number of training observations to sample from.}
+\item{ntrain}{Positive integer. Number of training observations to sample from.}
 
-\item{nTest}{Positive integer. Number of test observations to sample from.}
+\item{ntest}{Positive integer. Number of test observations to sample from.}
 
-\item{nosamp}{Positive integer. Number of samples.}
+\item{nsamples}{Positive integer. Number of samples.}
 
 \item{separate}{Logical indicating whether the train and test data should be sampled separately
 or in a joint sampling space. If they are sampled separately (which typically would be used when
@@ -21,7 +21,7 @@ training data. Not optimal, but for now fine if careful when using more samples 
 training observations while at the same time doing optimization over every test observation.}
 }
 \value{
-Data.frame. Contains \code{nosamp} rows of re-sampled train and test observations.
+Data.frame. Contains \code{nsamples} rows of re-sampled train and test observations.
 }
 \description{
 Helper function to sample a combination of training and testing rows, which does not risk

--- a/man/sample_combinations.Rd
+++ b/man/sample_combinations.Rd
@@ -18,7 +18,7 @@ sample_combinations(ntrain, ntest, nsamples, joint_sampling = TRUE)
 separately or in a joint sampling space. If they are sampled separately (which typically
 would be used when optimizing more than one distribution at once) we sample with replacement
 if \code{nsamples > ntrain}. Note that this solution is not optimal. Be careful if you're
-doing an optimization over every test observation when \code{nsamples > ntrain}.}
+doing optimization over every test observation when \code{nsamples > ntrain}.}
 }
 \value{
 Data.frame. Contains \code{nsamples} rows of re-sampled train and test observations.

--- a/man/sample_combinations.Rd
+++ b/man/sample_combinations.Rd
@@ -5,7 +5,7 @@
 \title{Helper function to sample a combination of training and testing rows, which does not risk
 getting the same observation twice. Need to improve this help file.}
 \usage{
-sample_combinations(ntrain, ntest, nsamples, separate = FALSE)
+sample_combinations(ntrain, ntest, nsamples, joint_sampling = TRUE)
 }
 \arguments{
 \item{ntrain}{Positive integer. Number of training observations to sample from.}
@@ -14,11 +14,11 @@ sample_combinations(ntrain, ntest, nsamples, separate = FALSE)
 
 \item{nsamples}{Positive integer. Number of samples.}
 
-\item{separate}{Logical indicating whether the train and test data should be sampled separately
-or in a joint sampling space. If they are sampled separately (which typically would be used when
-optimizing more than one distribution at once) we sample with replacement if more samples than
-training data. Not optimal, but for now fine if careful when using more samples than the number
-training observations while at the same time doing optimization over every test observation.}
+\item{joint_sampling}{Logical. Indicates whether train- and test data should be sampled
+separately or in a joint sampling space. If they are sampled separately (which typically
+would be used when optimizing more than one distribution at once) we sample with replacement
+if \code{nsamples > ntrain}. Note that this solution is not optimal. Be careful if you're
+doing an optimization over every test observation.when \code{nsamples > ntrain}.}
 }
 \value{
 Data.frame. Contains \code{nsamples} rows of re-sampled train and test observations.

--- a/tests/testthat/test-sample_combination.R
+++ b/tests/testthat/test-sample_combination.R
@@ -5,52 +5,52 @@ context("test-sample_combinations.R")
 test_that("Test sample_combinations", {
 
   # Example -----------
-  nTrain <- 10
-  nTest <- 10
-  nosamp <- 7
+  ntrain <- 10
+  ntest <- 10
+  nsamples <- 7
   separate <- TRUE
   cnms <- c("samp_train", "samp_test")
 
-  x <- sample_combinations(nTrain, nTest, nosamp, separate)
+  x <- sample_combinations(ntrain, ntest, nsamples, separate)
 
 
   # Tests -----------
   expect_true(is.data.frame(x))
   expect_equal(names(x), cnms)
-  expect_equal(nrow(x), nosamp)
+  expect_equal(nrow(x), nsamples)
 
-  # Expect all unique values when nosamp < nTrain
-  expect_true(length(unique(x$samp_train)) == nosamp)
-  expect_true(length(unique(x$samp_test)) == nosamp)
+  # Expect all unique values when nsamples < ntrain
+  expect_true(length(unique(x$samp_train)) == nsamples)
+  expect_true(length(unique(x$samp_test)) == nsamples)
 
-  expect_true(max(x$samp_train) <= nTrain)
-  expect_true(max(x$samp_test) <= nTest)
+  expect_true(max(x$samp_train) <= ntrain)
+  expect_true(max(x$samp_test) <= ntest)
 
   # Example -----------
-  nTrain <- 5
-  nTest <- 5
-  nosamp <- 7
+  ntrain <- 5
+  ntest <- 5
+  nsamples <- 7
   separate <- TRUE
 
-  x <- sample_combinations(nTrain, nTest, nosamp, separate)
+  x <- sample_combinations(ntrain, ntest, nsamples, separate)
 
   # Tests -----------
-  expect_true(max(x$samp_train) <= nTrain)
-  expect_true(max(x$samp_test) <= nTest)
-  expect_equal(nrow(x), nosamp)
+  expect_true(max(x$samp_train) <= ntrain)
+  expect_true(max(x$samp_test) <= ntest)
+  expect_equal(nrow(x), nsamples)
 
   # Example -----------
-  nTrain <- 5
-  nTest <- 5
-  nosamp <- 7
+  ntrain <- 5
+  ntest <- 5
+  nsamples <- 7
   separate <- FALSE
 
-  x <- sample_combinations(nTrain, nTest, nosamp, separate)
+  x <- sample_combinations(ntrain, ntest, nsamples, separate)
 
   # Tests -----------
-  expect_true(max(x$samp_train) <= nTrain)
-  expect_true(max(x$samp_test) <= nTest)
-  expect_equal(nrow(x), nosamp)
+  expect_true(max(x$samp_train) <= ntrain)
+  expect_true(max(x$samp_test) <= ntest)
+  expect_equal(nrow(x), nsamples)
 
 
 })

--- a/tests/testthat/test-sample_combination.R
+++ b/tests/testthat/test-sample_combination.R
@@ -8,10 +8,10 @@ test_that("Test sample_combinations", {
   ntrain <- 10
   ntest <- 10
   nsamples <- 7
-  separate <- TRUE
+  joint_sampling <- FALSE
   cnms <- c("samp_train", "samp_test")
 
-  x <- sample_combinations(ntrain, ntest, nsamples, separate)
+  x <- sample_combinations(ntrain, ntest, nsamples, joint_sampling)
 
 
   # Tests -----------
@@ -30,9 +30,9 @@ test_that("Test sample_combinations", {
   ntrain <- 5
   ntest <- 5
   nsamples <- 7
-  separate <- TRUE
+  joint_sampling <- FALSE
 
-  x <- sample_combinations(ntrain, ntest, nsamples, separate)
+  x <- sample_combinations(ntrain, ntest, nsamples, joint_sampling)
 
   # Tests -----------
   expect_true(max(x$samp_train) <= ntrain)
@@ -43,9 +43,9 @@ test_that("Test sample_combinations", {
   ntrain <- 5
   ntest <- 5
   nsamples <- 7
-  separate <- FALSE
+  joint_sampling <- TRUE
 
-  x <- sample_combinations(ntrain, ntest, nsamples, separate)
+  x <- sample_combinations(ntrain, ntest, nsamples, joint_sampling)
 
   # Tests -----------
   expect_true(max(x$samp_train) <= ntrain)


### PR DESCRIPTION
Motivation behind the changes of variable names; 
- We don't want a combination of `camelCase` and `snake_case` in our code. We've decided to use `snake_case` and hence I'm changing `nTrain` and `nTest` to `ntrain` and `ntest`. 
- When reading `nosamp` I thought it indicated "No sampling", hence I changed it to `nsamples`. 
- I think `joint_sampling` is more informative than `separate`. To understand the latter you have to read the documentation. 

@JensWahl What do you think? Does this makes sense?     