### PR TITLE
Bug: Explaining a single observation

### DIFF
--- a/R/shapley.R
+++ b/R/shapley.R
@@ -110,7 +110,7 @@ compute_kshap <- function(model,
     }
 
     # Reducing and re-ordering the D-array
-    l$D <- l$D[, , match(these_empirical, l$D_for_these_varcomb)]
+    l$D <- l$D[, , match(these_empirical, l$D_for_these_varcomb),drop=FALSE]
     # Note that the D-array corresponds to exactly the covariate combinations specified in
     # these_empirical
 


### PR DESCRIPTION
Added a drop to an array call, which otherwise reduce the array to a matrix when nrow(x_test)=1