### PR TITLE
Renames arguments related to aicc

### DIFF
--- a/R/explanation.R
+++ b/R/explanation.R
@@ -69,15 +69,15 @@ explain <- function(x, explainer, approach, prediction_zero, ...) {
 #' @param fixed_sigma_vec Vector or numeric. Only applicable when \code{approach='empirical'} and
 #' \code{type='fixed_sigma'}. The bandwidth to use. Default value \code{0.1}
 #'
-#' @param AICc_no_samp_per_optim Positive integer. Only applicable when
+#' @param n_samples_aicc Positive integer. Only applicable when
 #' \code{approach='empirical'} and \code{type='AICc_each_k'} or
 #' \code{type='AICc_full'}. Number of samples to consider in AICc optimization.
 #'
-#' @param AIC_optim_max_eval Positive integer. Only applicable when \code{approach='empirical'}
+#' @param eval_max_aicc Positive integer. Only applicable when \code{approach='empirical'}
 #' and \code{type='AICc_each_k'} or \code{type='AICc_full'}. Numeric. Maximum value when
 #' optimizing the AICc.
 #'
-#' @param AIC_optim_startval Numeric. Only applicable when \code{approach='empirical'} and
+#' @param start_aicc Numeric. Only applicable when \code{approach='empirical'} and
 #' \code{type='AICc_each_k'} or \code{type='AICc_full'}. Starting value when optimizing the AICc.
 #'
 #' @param w_threshold Positive integer between 0 and 1.
@@ -88,17 +88,17 @@ explain <- function(x, explainer, approach, prediction_zero, ...) {
 #' @export
 explain.empirical <- function(x, explainer, approach, prediction_zero,
                               type = "fixed_sigma", fixed_sigma_vec = 0.1,
-                              AICc_no_samp_per_optim = 1000, AIC_optim_max_eval = 20,
-                              AIC_optim_startval = 0.1, w_threshold = 0.95, ...) {
+                              n_samples_aicc = 1000, eval_max_aicc = 20,
+                              start_aicc = 0.1, w_threshold = 0.95, ...) {
 
   # Add arguments to explainer object
   explainer$x_test <- as.matrix(x)
   explainer$approach <- approach
   explainer$type <- type
   explainer$fixed_sigma_vec <- fixed_sigma_vec
-  explainer$AICc_no_samp_per_optim <- AICc_no_samp_per_optim
-  explainer$AIC_optim_max_eval <- AIC_optim_max_eval
-  explainer$AIC_optim_startval <- AIC_optim_startval
+  explainer$n_samples_aicc <- n_samples_aicc
+  explainer$eval_max_aicc <- eval_max_aicc
+  explainer$start_aicc <- start_aicc
   explainer$w_threshold <- w_threshold
 
   # Generate data

--- a/R/observations.R
+++ b/R/observations.R
@@ -249,10 +249,10 @@ compute_AICc_each_k <- function(x, h_optim_mat) {
   optimsamp <- sample_combinations(
     ntrain = nrow(x$x_train),
     ntest = nrow(x$x_test),
-    nsamples = x$AICc_no_samp_per_optim,
+    nsamples = x$n_samples_aicc,
     joint_sampling = FALSE
   )
-  x$AICc_no_samp_per_optim <- nrow(optimsamp)
+  x$n_samples_aicc <- nrow(optimsamp)
   nloops <- nrow(x$x_test) # No of observations in test data
 
   # Optimization is done only once for all distributions which conditions on
@@ -261,7 +261,7 @@ compute_AICc_each_k <- function(x, h_optim_mat) {
 
   for (i in these_k) {
     these_cond <- x$X[nfeatures == i, ID]
-    cutters <- 1:x$AICc_no_samp_per_optim
+    cutters <- 1:x$n_samples_aicc
     no_cond <- length(these_cond)
     cond_samp <- cut(
       x = cutters,
@@ -314,7 +314,7 @@ compute_AICc_each_k <- function(x, h_optim_mat) {
       names(y_list) <- NULL
       ## Doing the numerical optimization -------
       nlm.obj <- suppressWarnings(stats::nlminb(
-        start = x$AIC_optim_startval,
+        start = x$start_aicc,
         objective = aicc_full_cpp,
         X_list = X_list,
         mcov_list = mcov_list,
@@ -323,7 +323,7 @@ compute_AICc_each_k <- function(x, h_optim_mat) {
         negative = F,
         lower = 0,
         control = list(
-          eval.max = x$AIC_optim_max_eval
+          eval.max = x$eval_max_aicc
         )
       ))
       h_optim_mat[these_cond, loop] <- nlm.obj$par
@@ -343,10 +343,10 @@ compute_AICc_full <- function(x, h_optim_mat) {
   optimsamp <- sample_combinations(
     ntrain = nrow(x$x_train),
     ntest = ntest,
-    nsamples = x$AICc_no_samp_per_optim,
+    nsamples = x$n_samples_aicc,
     joint_sampling = FALSE
   )
-  x$AICc_no_samp_per_optim <- nrow(optimsamp)
+  x$n_samples_aicc <- nrow(optimsamp)
   nloops <- nrow(x$x_test) # No of observations in test data
 
   ind_of_vars_to_cond_on <- 2:(nrow(x$S) - 1)
@@ -385,7 +385,7 @@ compute_AICc_full <- function(x, h_optim_mat) {
 
       ## Running the nonlinear optimization
       nlm.obj <- suppressWarnings(stats::nlminb(
-        start = x$AIC_optim_startval,
+        start = x$start_aicc,
         objective = aicc_full_cpp,
         X_list = X_list,
         mcov_list = mcov_list,
@@ -394,7 +394,7 @@ compute_AICc_full <- function(x, h_optim_mat) {
         negative = F,
         lower = 0,
         control = list(
-          eval.max = x$AIC_optim_max_eval
+          eval.max = x$eval_max_aicc
         )
       ))
 

--- a/R/shapley.R
+++ b/R/shapley.R
@@ -165,9 +165,9 @@ compute_kshap <- function(model,
                           empirical_settings = list(
                             type = "fixed_sigma",
                             fixed_sigma_vec = 0.1,
-                            AICc_no_samp_per_optim = 1000,
-                            AIC_optim_max_eval = 20,
-                            AIC_optim_startval = 0.1,
+                            n_samples_aicc = 1000,
+                            eval_max_aicc = 20,
+                            start_aicc = 0.1,
                             w_threshold = 0.95
                           ),
                           pred_zero,
@@ -229,12 +229,12 @@ compute_kshap <- function(model,
         optimsamp <- sample_combinations(
           ntrain = nrow(l$Xtrain),
           ntest = nrow(l$Xtest),
-          nsamples = empirical_settings$AICc_no_samp_per_optim,
+          nsamples = empirical_settings$n_samples_aicc,
           joint_sampling = FALSE
         )
 
         # Updating parameter (only if it is larger than nTrain*nTest)
-        empirical_settings$AICc_no_samp_per_optim <- nrow(optimsamp)
+        empirical_settings$n_samples_aicc <- nrow(optimsamp)
 
         nloops <- nrow(l$Xtest)
 
@@ -246,7 +246,7 @@ compute_kshap <- function(model,
 
           for (i in these_k) {
             these_cond <- l$X[ID %in% these_empirical][nfeatures == i, ID]
-            cutters <- 1:empirical_settings$AICc_no_samp_per_optim
+            cutters <- 1:empirical_settings$n_samples_aicc
             no_cond <- length(these_cond)
 
             cond_samp <- cut(
@@ -301,7 +301,7 @@ compute_kshap <- function(model,
 
               ## Doing the numerical optimization -------
               nlm.obj <- suppressWarnings(stats::nlminb(
-                start = empirical_settings$AIC_optim_startval,
+                start = empirical_settings$start_aicc,
                 objective = aicc_full_cpp,
                 X_list = X_list,
                 mcov_list = mcov_list,
@@ -310,7 +310,7 @@ compute_kshap <- function(model,
                 negative = F,
                 lower = 0,
                 control = list(
-                  eval.max = empirical_settings$AIC_optim_max_eval,
+                  eval.max = empirical_settings$eval_max_aicc,
                   trace = verbose
                 )
               ))
@@ -355,7 +355,7 @@ compute_kshap <- function(model,
               ## Running the nonlinear optimization
 
               nlm.obj <- suppressWarnings(stats::nlminb(
-                start = empirical_settings$AIC_optim_startval,
+                start = empirical_settings$start_aicc,
                 objective = aicc_full_cpp,
                 X_list = X_list,
                 mcov_list = mcov_list,
@@ -364,7 +364,7 @@ compute_kshap <- function(model,
                 negative = F,
                 lower = 0,
                 control = list(
-                  eval.max = empirical_settings$AIC_optim_max_eval,
+                  eval.max = empirical_settings$eval_max_aicc,
                   trace = verbose
                 )
               ))

--- a/man/compute_kshap.Rd
+++ b/man/compute_kshap.Rd
@@ -7,9 +7,9 @@ to check that results are stable.}
 \usage{
 compute_kshap(model, l, noSamp_MC = 1000, verbose = FALSE,
   cond_approach = "empirical", empirical_settings = list(type =
-  "fixed_sigma", fixed_sigma_vec = 0.1, AICc_no_samp_per_optim = 1000,
-  AIC_optim_max_eval = 20, AIC_optim_startval = 0.1, w_threshold = 0.95),
-  pred_zero, mu = NULL, Sigma = NULL, ensure_condcov_symmetry = F)
+  "fixed_sigma", fixed_sigma_vec = 0.1, n_samples_aicc = 1000,
+  eval_max_aicc = 20, start_aicc = 0.1, w_threshold = 0.95), pred_zero,
+  mu = NULL, Sigma = NULL, ensure_condcov_symmetry = F)
 }
 \description{
 TODO: Delete this function from the codebase

--- a/man/explain.Rd
+++ b/man/explain.Rd
@@ -11,9 +11,8 @@
 explain(x, explainer, approach, prediction_zero, ...)
 
 \method{explain}{empirical}(x, explainer, approach, prediction_zero,
-  type = "fixed_sigma", fixed_sigma_vec = 0.1,
-  AICc_no_samp_per_optim = 1000, AIC_optim_max_eval = 20,
-  AIC_optim_startval = 0.1, w_threshold = 0.95, ...)
+  type = "fixed_sigma", fixed_sigma_vec = 0.1, n_samples_aicc = 1000,
+  eval_max_aicc = 20, start_aicc = 0.1, w_threshold = 0.95, ...)
 
 \method{explain}{gaussian}(x, explainer, approach, prediction_zero,
   mu = NULL, cov_mat = NULL, ...)
@@ -45,15 +44,15 @@ the response.}
 \item{fixed_sigma_vec}{Vector or numeric. Only applicable when \code{approach='empirical'} and
 \code{type='fixed_sigma'}. The bandwidth to use. Default value \code{0.1}}
 
-\item{AICc_no_samp_per_optim}{Positive integer. Only applicable when
+\item{n_samples_aicc}{Positive integer. Only applicable when
 \code{approach='empirical'} and \code{type='AICc_each_k'} or
 \code{type='AICc_full'}. Number of samples to consider in AICc optimization.}
 
-\item{AIC_optim_max_eval}{Positive integer. Only applicable when \code{approach='empirical'}
+\item{eval_max_aicc}{Positive integer. Only applicable when \code{approach='empirical'}
 and \code{type='AICc_each_k'} or \code{type='AICc_full'}. Numeric. Maximum value when
 optimizing the AICc.}
 
-\item{AIC_optim_startval}{Numeric. Only applicable when \code{approach='empirical'} and
+\item{start_aicc}{Numeric. Only applicable when \code{approach='empirical'} and
 \code{type='AICc_each_k'} or \code{type='AICc_full'}. Starting value when optimizing the AICc.}
 
 \item{w_threshold}{Positive integer between 0 and 1.}

--- a/tests/testthat/test-refactor.R
+++ b/tests/testthat/test-refactor.R
@@ -71,9 +71,9 @@ test_that("Test new", {
   empirical_settings <- list(
     type = "AICc_each_k",
     fixed_sigma_vec = 0.1,
-    AICc_no_samp_per_optim = 20,
-    AIC_optim_max_eval = 20,
-    AIC_optim_startval = 0.1,
+    n_samples_aicc = 20,
+    eval_max_aicc = 20,
+    start_aicc = 0.1,
     w_threshold = 0.95
   )
   e5_new <- explain(x_test, explainer, approach = "empirical", prediction_zero = mean(y_train), type = "AICc_each_k")
@@ -89,9 +89,9 @@ test_that("Test new", {
   empirical_settings <- list(
     type = "AICc_full",
     fixed_sigma_vec = 0.1,
-    AICc_no_samp_per_optim = 20,
-    AIC_optim_max_eval = 20,
-    AIC_optim_startval = 0.1,
+    n_samples_aicc = 20,
+    eval_max_aicc = 20,
+    start_aicc = 0.1,
     w_threshold = 0.95
   )
   e6_new <- explain(x_test, explainer, approach = "empirical", prediction_zero = mean(y_train), type = "AICc_full")


### PR DESCRIPTION
Renames the following arguments: 
- `AICc_no_samp_per_optim` to `n_samples_aicc`  
- `AIC_optim_max_eval` to `eval_max_aicc`
- `AIC_optim_startval` to `start_aicc`