### PR TITLE
Bugfix in shapr

### DIFF
--- a/R/shapley.R
+++ b/R/shapley.R
@@ -83,10 +83,8 @@ shapr <- function(x,
   # Checks model and features
   explainer$p <- predict_model(model, head(x))
 
-  # Create data.table --------------
-  if (!data.table::is.data.table(x)) {
-    x_train <- data.table::as.data.table(x)
-  }
+  # Converts to data.table, otherwise copy to x_train  --------------
+  x_train <- data.table::as.data.table(x)
 
   # Get all combinations ----------------
   dt_combinations <- feature_combinations(


### PR DESCRIPTION
Fixes bug when x in shapr is a data.table. 
Typically worked OK before as x_train accidentally was a global variable.
Also, it is probably smart to not do x_train <- x, but rather make x_train a copy of x (as as.data.table(x) does when x is a data.table), since changing x afterwords should not affect explainer$x_train.

Example script
```
library(shapr)

data("Boston", package = "MASS")

x_var <- c("lstat", "rm", "dis", "indus")
y_var <- "medv"

x_train0 <- as.matrix(tail(Boston[, x_var], -6))
y_train <- tail(Boston[, y_var], -6)


# Fitting a basic xgboost model to the training data
model <- xgboost::xgboost(
  data = x_train0,
  label = y_train,
  nround = 20,
  verbose = FALSE
)
aa = data.table::as.data.table(x_train0)
# THIS USED TO THREW AN ERROR
explainer <- shapr(aa, model) 

all.equal(explainer$x_train,aa) # Should be identical
#[1] TRUE

# Changing aa should not change explainer$x_train
aa[,lstat:=1]
#explainer$x_train
all.equal(explainer$x_train,aa)
#[1] "Column 'lstat': Mean relative difference: 0.9215172"

```