### PR TITLE
Renames x_test in prepare_data.copula

### DIFF
--- a/R/explanation.R
+++ b/R/explanation.R
@@ -168,7 +168,6 @@ explain.copula <- function(x, explainer, approach, prediction_zero, ...) {
 
   # Setup
   explainer$x_test <- as.matrix(x)
-  explainer$x_test <- x
   explainer$approach <- approach
 
   # Prepare transformed data
@@ -177,14 +176,15 @@ explain.copula <- function(x, explainer, approach, prediction_zero, ...) {
     MARGIN = 2,
     FUN = gaussian_transform
   )
-  x_test <- apply(
+  x_test_gaussian <- apply(
     X = rbind(explainer$x_test, explainer$x_train),
     MARGIN = 2,
     FUN = gaussian_transform_separate,
     n_y = nrow(explainer$x_test)
   )
-  if (is.null(dim(x))) {
-    x_test <- t(as.matrix(x))
+
+  if (is.null(dim(x_test_gaussian))) {
+    x_test_gaussian <- t(as.matrix(x_test_gaussian))
   }
 
   explainer$mu <- rep(0, ncol(explainer$x_train))
@@ -196,7 +196,7 @@ explain.copula <- function(x, explainer, approach, prediction_zero, ...) {
     explainer$cov_mat <- cov_mat
   }
   # Generate data
-  dt <- prepare_data(explainer, x_test = x_test, ...)
+  dt <- prepare_data(explainer, x_test_gaussian = x_test_gaussian, ...)
   if (!is.null(explainer$return)) return(dt)
 
   # Predict

--- a/R/observations.R
+++ b/R/observations.R
@@ -210,7 +210,7 @@ prepare_data.gaussian <- function(x, seed = 1, n_samples = 1e3, index_features =
 #' @rdname prepare_data
 #' @name prepare_data
 #' @export
-prepare_data.copula <- function(x, x_test = 1, seed = 1, n_samples = 1e3, index_features = NULL, ...) {
+prepare_data.copula <- function(x, x_test_gaussian = 1, seed = 1, n_samples = 1e3, index_features = NULL, ...) {
 
   n_xtest <- nrow(x$x_test)
   dt_l <- list()
@@ -231,7 +231,7 @@ prepare_data.copula <- function(x, x_test = 1, seed = 1, n_samples = 1e3, index_
       p = ncol(x$x_test),
       x_test = x$x_test[i, , drop = FALSE],
       x_train = as.matrix(x$x_train),
-      x_test_gaussian = x_test[i, , drop = FALSE]
+      x_test_gaussian = x_test_gaussian[i, , drop = FALSE]
     )
 
     dt_l[[i]] <- data.table::rbindlist(l, idcol = "wcomb")

--- a/man/prepare_data.Rd
+++ b/man/prepare_data.Rd
@@ -15,7 +15,7 @@ prepare_data(x, ...)
 \method{prepare_data}{gaussian}(x, seed = 1, n_samples = 1000,
   index_features = NULL, ...)
 
-\method{prepare_data}{copula}(x, x_test = 1, seed = 1,
+\method{prepare_data}{copula}(x, x_test_gaussian = 1, seed = 1,
   n_samples = 1000, index_features = NULL, ...)
 }
 \arguments{


### PR DESCRIPTION
Renamed `x_test` to `x_test_gaussian` in `prepare_data.copula`. 

In addition to this there's also a bug fix for the case when you only pass a single test observation. See the lines where we did `if (is.null(dim(x))`. 

To streamline this, the variables was also changed in `explain.copula`.   