### PR TITLE
Renames ncomb to n_combinations

### DIFF
--- a/src/weighted_matrix.cpp
+++ b/src/weighted_matrix.cpp
@@ -86,16 +86,16 @@ arma::mat weight_matrix_cpp(List features, int m, int n, NumericVector w){
 NumericMatrix feature_matrix_cpp(List features, int m) {
 
     // Define variables
-    int ncomb;
-    ncomb = features.length();
-    NumericMatrix A(ncomb, m);
+    int n_combinations;
+    n_combinations = features.length();
+    NumericMatrix A(n_combinations, m);
 
     // Error-check
     IntegerVector features_zero = features[0];
     if (features_zero.length() > 0)
         Rcpp::stop("The first element of features should be an empty vector, i.e. integer(0)");
 
-    for (int i = 1; i < ncomb; ++i) {
+    for (int i = 1; i < n_combinations; ++i) {
 
         NumericVector feature_vec = features[i];
 

--- a/tests/testthat/test-src_impute_data.R
+++ b/tests/testthat/test-src_impute_data.R
@@ -11,12 +11,12 @@ test_that("Test observation_impute_cpp", {
 
   # Example -----------
   m <- 3
-  ncomb <- 2^m
+  n_combinations <- 2^m
   mtcars <- mtcars[1:15, seq(m)]
   ntrain <- 14
   xtrain <- mtcars[seq(ntrain), ]
   xtest <- mtcars[-seq(ntrain), , drop = FALSE]
-  S <- matrix(0L, ncomb, m)
+  S <- matrix(0L, n_combinations, m)
   features <- list(
     integer(), 1, 2, 3, c(1, 2), c(1, 3), c(2, 3), c(1, 2, 3)
   )


### PR DESCRIPTION
We're using `n_combinations` everywhere, and c++ code should also do this. 