### PR TITLE
Fixes notes when running R CMD check

### DIFF
--- a/R/features.R
+++ b/R/features.R
@@ -135,16 +135,14 @@ feature_not_exact <- function(m, n_combinations = 200, weight_zero_m = 10^6) {
   X[, is_duplicate := NULL]
 
   # Add shapley weight and number of combinations
-  ind <- NULL # due to NSE notes in R CMD check
   X[c(1, .N), shapley_weight := weight_zero_m]
   X[, N := 1]
-  X[between(n_features, 1, m - 1), ind := TRUE]
-  X[ind == TRUE, p := p[n_features]]
-  X[ind == TRUE, N := n[n_features]]
-  X[, ind := NULL]
+  ind <- X[, .I[between(n_features, 1, m - 1)]]
+  X[ind, p := p[n_features]]
+  X[ind, N := n[n_features]]
 
   # Set column order and key table
-  data.table::setkey(X, n_features)
+  data.table::setkeyv(X, "n_features")
   X[, id_combination := .I]
   X[, N := as.integer(N)]
   nms <- c("id_combination", "features", "n_features", "N", "shapley_weight", "p")

--- a/R/features.R
+++ b/R/features.R
@@ -62,6 +62,11 @@ feature_combinations <- function(m, exact = TRUE, n_combinations = 200, weight_z
     dt <- feature_exact(m, weight_zero_m)
   } else {
     dt <- feature_not_exact(m, n_combinations, weight_zero_m)
+    stopifnot(
+      data.table::is.data.table(dt),
+      !is.null(dt[["p"]])
+    )
+    p <- NULL # due to NSE notes in R CMD check
     dt[, p := NULL]
   }
 
@@ -70,6 +75,8 @@ feature_combinations <- function(m, exact = TRUE, n_combinations = 200, weight_z
 
 #' @keywords internal
 feature_exact <- function(m, weight_zero_m = 10^6) {
+
+  features <- id_combination <- n_features <- shapley_weight <- N <- NULL # due to NSE notes in R CMD check
 
   dt <- data.table::data.table(id_combination = seq(2^m))
   combinations <- lapply(0:m, utils::combn, x = m, simplify = FALSE)
@@ -83,6 +90,8 @@ feature_exact <- function(m, weight_zero_m = 10^6) {
 
 #' @keywords internal
 feature_not_exact <- function(m, n_combinations = 200, weight_zero_m = 10^6) {
+
+  features <- id_combination <- n_features <- shapley_weight <- N <- NULL # due to NSE notes in R CMD check
 
   # Find weights for given number of features ----------
   n_features <- seq(m - 1)
@@ -106,10 +115,11 @@ feature_not_exact <- function(m, n_combinations = 200, weight_zero_m = 10^6) {
   X[, n_features := as.integer(n_features)]
 
   # Sample specific set of features -------
-  data.table::setkey(X, n_features)
+  data.table::setkeyv(X, "n_features")
   feature_sample <- sample_features_cpp(m, X[["n_features"]])
 
   # Get number of occurences and duplicated rows-------
+  is_duplicate <- NULL # due to NSE notes in R CMD check
   r <- helper_feature(m, feature_sample)
   X[, is_duplicate := r[["is_duplicate"]]]
 
@@ -125,6 +135,7 @@ feature_not_exact <- function(m, n_combinations = 200, weight_zero_m = 10^6) {
   X[, is_duplicate := NULL]
 
   # Add shapley weight and number of combinations
+  ind <- NULL # due to NSE notes in R CMD check
   X[c(1, .N), shapley_weight := weight_zero_m]
   X[, N := 1]
   X[between(n_features, 1, m - 1), ind := TRUE]
@@ -144,6 +155,8 @@ feature_not_exact <- function(m, n_combinations = 200, weight_zero_m = 10^6) {
 
 #' @keywords internal
 helper_feature <- function(m, feature_sample) {
+
+  sample_frequence <- is_duplicate <- NULL  # due to NSE notes in R CMD check
 
   x <- feature_matrix_cpp(feature_sample, m)
   dt <- data.table::data.table(x)

--- a/R/observations.R
+++ b/R/observations.R
@@ -44,6 +44,7 @@ observation_impute <- function(W_kernel, S, x_train, x_test, w_threshold = .7, n
   stopifnot(nrow(W_kernel) == nrow(x_train))
   stopifnot(ncol(W_kernel) == nrow(S))
   stopifnot(all(S %in% c(0, 1)))
+  index_s <- index_x_train <- id_combination <- weight <- w <- wcum <- NULL # due to NSE notes in R CMD check
 
   # Find weights for all combinations and training data
   dt <- data.table::as.data.table(W_kernel)
@@ -62,12 +63,12 @@ observation_impute <- function(W_kernel, S, x_train, x_test, w_threshold = .7, n
   # Remove training data with small weight
   knms <- c("index_s", "weight")
   data.table::setkeyv(dt_melt, knms)
-  dt_melt[, weight := weight / sum(weight), index_s]
+  dt_melt[, weight := weight / sum(weight), by = "index_s"]
   if (w_threshold < 1) {
     dt_melt[, wcum := cumsum(weight), index_s]
     dt_melt <- dt_melt[wcum > 1 - w_threshold][, wcum := NULL]
   }
-  dt_melt <- dt_melt[, tail(.SD, n_samples), index_s]
+  dt_melt <- dt_melt[, tail(.SD, n_samples), by = "index_s"]
 
   # Generate data used for prediction
   dt_p <- observation_impute_cpp(
@@ -114,6 +115,8 @@ prepare_data <- function(x, ...) {
 #' @export
 prepare_data.empirical <- function(x, seed = 1, n_samples = 1e3, index_features = NULL, ...) {
 
+  id <- id_combination <- w <- NULL # due to NSE notes in R CMD check
+
   # Get distance matrix ----------------
   if (is.null(index_features)) {
     index_features <- x$X[, .I]
@@ -133,6 +136,7 @@ prepare_data.empirical <- function(x, seed = 1, n_samples = 1e3, index_features 
   h_optim_mat <- matrix(NA, ncol = n_col, nrow = no_empirical)
   h_optim_DT <- as.data.table(h_optim_mat)
   data.table::setnames(h_optim_DT, paste0("Testobs_", seq(nrow(x$x_test))))
+  varcomb <- NULL # due to NSE notes in R CMD check
   h_optim_DT[, varcomb := .I]
   kernel_metric <- ifelse(x$type == "independence", x$type, "gaussian")
 
@@ -182,6 +186,7 @@ prepare_data.empirical <- function(x, seed = 1, n_samples = 1e3, index_features 
   }
 
   dt <- data.table::rbindlist(dt_l, use.names = TRUE, fill = TRUE)
+  V1 <- keep <- NULL # due to NSE notes in R CMD check
   dt[, keep := TRUE]
   first_element <- dt[, tail(.I, 1), .(id, id_combination)][id_combination %in% c(1, 2^ncol(x$x_test)), V1]
   dt[id_combination %in% c(1, 2^ncol(x$x_test)), keep := FALSE]
@@ -194,6 +199,8 @@ prepare_data.empirical <- function(x, seed = 1, n_samples = 1e3, index_features 
 #' @rdname prepare_data
 #' @export
 prepare_data.gaussian <- function(x, seed = 1, n_samples = 1e3, index_features = NULL, ...) {
+
+  id <- id_combination <- w <- NULL # due to NSE notes in R CMD check
 
   n_xtest <- nrow(x$x_test)
   dt_l <- list()
@@ -230,6 +237,7 @@ prepare_data.gaussian <- function(x, seed = 1, n_samples = 1e3, index_features =
 #' @export
 prepare_data.copula <- function(x, x_test_gaussian = 1, seed = 1, n_samples = 1e3, index_features = NULL, ...) {
 
+  id <- id_combination <- w <- NULL # due to NSE notes in R CMD check
   n_xtest <- nrow(x$x_test)
   dt_l <- list()
   if (!is.null(seed)) set.seed(seed)
@@ -264,6 +272,14 @@ prepare_data.copula <- function(x, x_test_gaussian = 1, seed = 1, n_samples = 1e
 
 #' @keywords internal
 compute_AICc_each_k <- function(x, h_optim_mat) {
+
+  id_combination <- n_features <- NULL # due to NSE notes in R CMD check
+  stopifnot(
+    data.table::is.data.table(x$X),
+    !is.null(x$X[["id_combination"]]),
+    !is.null(x$X[["n_features"]])
+  )
+
   optimsamp <- sample_combinations(
     ntrain = nrow(x$x_train),
     ntest = nrow(x$x_test),
@@ -302,7 +318,7 @@ compute_AICc_each_k <- function(x, h_optim_mat) {
         these_test <- this.optimsamp$samp_test[these_inds]
 
         these_train <- 1:nrow(x$x_train)
-        these_test <- sample(x = these_test, size = nrow(x$x_train), replace = T)
+        these_test <- sample(x = these_test, size = nrow(x$x_train), replace = TRUE)
         current_cond_samp <- rep(unique(cond_samp), each = nrow(x$x_train))
 
         S <- x$S[this_cond, ]

--- a/R/observations.R
+++ b/R/observations.R
@@ -65,7 +65,7 @@ observation_impute <- function(W_kernel, S, x_train, x_test, w_threshold = .7, n
   data.table::setkeyv(dt_melt, knms)
   dt_melt[, weight := weight / sum(weight), by = "index_s"]
   if (w_threshold < 1) {
-    dt_melt[, wcum := cumsum(weight), index_s]
+    dt_melt[, wcum := cumsum(weight), by = "index_s"]
     dt_melt <- dt_melt[wcum > 1 - w_threshold][, wcum := NULL]
   }
   dt_melt <- dt_melt[, tail(.SD, n_samples), by = "index_s"]

--- a/R/plot.R
+++ b/R/plot.R
@@ -34,9 +34,10 @@ plot.shapr <- function(x,
 
   if (is.null(index_x_test)) index_x_test <- seq(nrow(x$x_test))
   if (is.null(top_k_features)) top_k_features <- ncol(x$x_test) + 1
-  cnms <- colnames(x$x_test)
+  id <- phi <- NULL # due to NSE notes in R CMD check
 
   # melting Kshap
+  cnms <- colnames(x$x_test)
   KshapDT <- data.table::copy(x$dt)
   KshapDT[, id := .I]
   meltKshap <- data.table::melt(KshapDT, id.vars = "id", value.name = "phi")
@@ -58,13 +59,14 @@ plot.shapr <- function(x,
   plotting_dt <- merge(plotting_dt, predDT, by = "id")
 
   # Adding header for each individual plot
+  header <- variable <- pred <- description <- NULL # due to NSE notes in R CMD check
   plotting_dt[, header := paste0("id: ", id, ", pred = ", format(pred, digits = digits + 1))]
 
   if (!plot_phi0) {
     plotting_dt <- plotting_dt[variable != "none"]
   }
   plotting_dt <- plotting_dt[id %in% index_x_test]
-  plotting_dt[, rank := data.table::frank(-abs(phi)), by = id]
+  plotting_dt[, rank := data.table::frank(-abs(phi)), by = "id"]
   plotting_dt <- plotting_dt[rank <= top_k_features]
   plotting_dt[, description := factor(description, levels = unique(description[order(abs(phi))]))]
 

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -31,6 +31,15 @@
 #' @author Nikolai Sellereite
 prediction <- function(dt, prediction_zero, explainer) {
 
+  # Checks on input data
+  id <- w <- id_combination <- p_hat <- NULL # due to NSE notes in R CMD check
+  stopifnot(
+    data.table::is.data.table(dt),
+    !is.null(dt[["id"]]),
+    !is.null(dt[["id_combination"]]),
+    !is.null(dt[["w"]])
+  )
+
   # Setup
   cnms <- colnames(explainer$x_test)
   data.table::setkeyv(dt, c("id", "id_combination"))


### PR DESCRIPTION
See https://rdatatable.gitlab.io/data.table/articles/datatable-importing.html#namespace-file-namespace for more information about the problem.  

What I'm thinking with these changes:  
If we add a variable `s` in data.table inside a function we do `s <- NULL` first. If we modify or use a variable in data.table that was passed as an argument in the function, we first check if it is actually a data.table, and if so, we also check if the column we want to modify/use exists. 

**Example 1**
```
foo1 <- function() {
  x3 <- NULL
  x <- data.table::data.table(x1 = 1:10, x2 = 1:10)
  x[, x3 := 1e2]
  return(x)
}
x1 <- foo1()
x1[]
```

**Example 2**
```
foo2 <- function(x) {
  
  x3 <- NULL
  stopifnot(
    data.table::is.data.table(x), 
    !is.null(x[["x3"]])
  )
  x[, x3 := x3^2]
  return(x)
}


x2 <- foo2(foo1())
x2[]
```

Doesn't look pretty, but I'd like to avoid adding them as global variables in `R/zzz.R` as we did previously. We lose a bit a control when doing that.  

Fixes #12 .