### PR TITLE
Fixes for R-devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shapr
 Version: 0.1.1
-Title: Explain the output of machine learning models with more accurately estimated Shapley values 
+Title: Explain the Output of Machine Learning Models with more Accurately Estimated Shapley Values
 Description: Complex machine learning models are often hard to interpret. However, in 
   many situations it is crucial to understand and explain why a model made a specific 
   prediction. Shapley values is the only method for such prediction explanation framework 
@@ -37,7 +37,6 @@ Suggests:
     testthat, 
     lintr (>= 2.0.0),
     covr,
-    maptree,
     corrplot,
     pcaPP,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Suggests:
     testthat, 
     lintr (>= 2.0.0),
     covr,
+    maptree,
     corrplot,
     pcaPP,
     knitr,

--- a/tests/testthat/test-a-shapley.R
+++ b/tests/testthat/test-a-shapley.R
@@ -3,7 +3,7 @@ library(shapr)
 
 context("test-shapley.R")
 
-if (as.numeric(version$minor) >= 6.0) RNGkind(sample.kind = "Rounding")
+RNGkind(sample.kind = "Rounding")
 
 test_that("Basic test functions in shapley.R", {
 

--- a/tests/testthat/test-a-shapley.R
+++ b/tests/testthat/test-a-shapley.R
@@ -3,7 +3,7 @@ library(shapr)
 
 context("test-shapley.R")
 
-RNGkind(sample.kind = "Rounding")
+RNGversion(vstr = "3.5.0")
 
 test_that("Basic test functions in shapley.R", {
 

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -4,7 +4,7 @@ library(shapr)
 context("test-explanation.R")
 
 # For using same Random numer generator as CircelCI (R version 3.5.x)
-RNGkind(sample.kind = "Rounding")
+RNGversion(vstr = "3.5.0")
 
 test_that("Test functions in explanation.R", {
 

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -4,7 +4,7 @@ library(shapr)
 context("test-explanation.R")
 
 # For using same Random numer generator as CircelCI (R version 3.5.x)
-if (as.numeric(version$minor) >= 6.0) RNGkind(sample.kind = "Rounding")
+RNGkind(sample.kind = "Rounding")
 
 test_that("Test functions in explanation.R", {
 


### PR DESCRIPTION
- Uppercase on package title, to make R-devel happy
- Switch the way to specify seed type in tests to allow running on R version 3.5, 3.6 and 4.0 (the previous failed on 4.0 due to the way it was coded). Setting seed type based on R version is clearer than RNGkind and it does the same thing.