### PR TITLE
Delete old artifacts

### DIFF
--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -17,4 +17,4 @@ with:
   age: '1 week'
 # Optional inputs
 # skip-tags: true
- skip-recent: 5
+ skip-recent: 6

--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -1,0 +1,20 @@
+name: Remove old artifacts
+
+on:
+  schedule:
+  # Every day at 1am
+  - cron: '0 1 * * *'
+
+jobs:
+  remove-old-artifacts:
+  runs-on: ubuntu-latest
+timeout-minutes: 10
+
+steps:
+  - name: Remove old artifacts
+uses: c-hive/gha-remove-artifacts@v1
+with:
+  age: '1 week'
+# Optional inputs
+# skip-tags: true
+ skip-recent: 5


### PR DESCRIPTION
Storing artifacts from failed jobs on GitHub actions is eating our storage quota on GitHub when there are many failed jobs.

I don't think the artifacts are really useful longer than right after you had a failed job and want to investigate why that has happened. Therefore, regularly deleting artifacts older than a week, while always keeping the last 6 artifacts (we have 6 R CMD jobs) seems sufficient. 

I have played around with this on https://github.com/martinju/shapr, https://github.com/martinju/shapr/actions and confirmed the workflow works as intended. 

See also https://github.community/t/managing-actions-storage-space/16973

While this repo is not producing very large files, there can be quite a few of them over time, so regularly deleting them seems like good practice. 