### PR TITLE
Fix model type bug for xgboost with categorical data and classication

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -105,7 +105,7 @@ predict_model.xgb.Booster <- function(x, newdata) {
   # Test model type
   model_type <- model_type(x)
 
-  if (model_type == "cat_regression") {
+  if (model_type %in% c("cat_regression","cat_classification") ) {
     newdata_dummy <- apply_dummies(obj = x$dummylist, newdata = newdata)
     predict(x, as.matrix(newdata_dummy))
   } else {
@@ -246,7 +246,7 @@ model_type.xgb.Booster <- function(x) {
 
   ifelse(
     !is.null(x$params$objective) && x$params$objective == "binary:logistic",
-    "classification",
+    ifelse(is.null(x$dummylist), "classification", "cat_classification"),
     ifelse(is.null(x$dummylist), "regression", "cat_regression")
   )
 }


### PR DESCRIPTION
The model_type for xgboost does not return a string calling on the dummylist procedure when using classifaiction (with a probability) with xgboost (only regression). Fixing this here. Should be merged to related branches too.