### PR TITLE
Use suggested packages conditionally -- Get back on CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,11 @@ on:
   push:
     branches:
       - master
+      - cranversion
   pull_request:
     branches:
       - master
+      - cranversion
 
 name: R-CMD-check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,11 @@ on:
   push:
     branches:
       - master
+      - cranversion
   pull_request:
     branches:
       - master
+      - cranversion
 
 name: lint
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,8 @@
 on:
   push:
-    branches: master
+    branches:
+      - master
+      - cranversion
 
 name: pkgdown
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: shapr
-Version: 0.1.3
+Version: 0.1.4
 Title: Prediction Explanation with Dependence-Aware Shapley Values
 Description: Complex machine learning models are often hard to interpret. However, in 
   many situations it is crucial to understand and explain why a model made a specific 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # shapr 0.1.4
 
-* Using all packages under Suggests conditionally in tests
+* Patch to fulfill CRAN policy of using packages under Suggests conditionally (in tests and examples)
 
 # shapr 0.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
 
+# shapr 0.1.4
+
+* Using all packages under Suggests conditionally in tests
+
 # shapr 0.1.3
 
 * Fix installation error on Solaris

--- a/R/explanation.R
+++ b/R/explanation.R
@@ -62,6 +62,7 @@
 #' @author Camilla Lingjaerde, Nikolai Sellereite
 #'
 #' @examples
+#' if (requireNamespace("MASS", quietly = TRUE)) {
 #' # Load example data
 #' data("Boston", package = "MASS")
 #'
@@ -95,7 +96,10 @@
 #' print(explain1$dt)
 #'
 #' # Plot the results
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
 #' plot(explain1)
+#' }
+#' }
 explain <- function(x, explainer, approach, prediction_zero, ...) {
 
   # Check input for x

--- a/R/models.R
+++ b/R/models.R
@@ -36,6 +36,7 @@
 #'
 #' @author Martin Jullum
 #' @examples
+#' if (requireNamespace("MASS", quietly = TRUE)) {
 #'# Load example data
 #' data("Boston", package = "MASS")
 #' # Split data into test- and training data
@@ -46,6 +47,7 @@
 #'
 #' # Predicting for a model with a standardized format
 #' predict_model(x = model, newdata = x_test)
+#' }
 predict_model <- function(x, newdata) {
   UseMethod("predict_model", x)
 }
@@ -158,6 +160,7 @@ predict_model.gam <- function(x, newdata) {
 #' @keywords internal
 #'
 #' @examples
+#' if (requireNamespace("MASS", quietly = TRUE)) {
 #' # Load example data
 #' data("Boston", package = "MASS")
 #' # Split data into test- and training data
@@ -167,6 +170,7 @@ predict_model.gam <- function(x, newdata) {
 #'
 #' # Writing out the defined model type of the object
 #' model_type(x = model)
+#' }
 model_type <- function(x) {
   UseMethod("model_type")
 }
@@ -282,6 +286,7 @@ model_type.xgb.Booster <- function(x) {
 #' @keywords internal
 #'
 #' @examples
+#' if (requireNamespace("MASS", quietly = TRUE)) {
 #'# Load example data
 #' data("Boston", package = "MASS")
 #' # Split data into test- and training data
@@ -293,6 +298,7 @@ model_type.xgb.Booster <- function(x) {
 #'
 #' # Checking that features used by the model corresponds to cnms
 #' features(x = model, cnms = cnms, feature_labels = NULL)
+#' }
 features <- function(x, cnms, feature_labels = NULL) {
   UseMethod("features", x)
 }

--- a/R/plot.R
+++ b/R/plot.R
@@ -20,6 +20,7 @@
 #'
 #' @export
 #' @examples
+#' if (requireNamespace("MASS", quietly = TRUE)) {
 #' #' # Load example data
 #' data("Boston", package = "MASS")
 #'
@@ -43,8 +44,11 @@
 #'                       prediction_zero = p,
 #'                       n_samples = 1e2)
 #'
+#'if (requireNamespace("ggplot2", quietly = TRUE)) {
 #' # Plot the explantion (this function)
 #' plot(explanation)
+#' }
+#' }
 #'
 #' @author Martin Jullum
 plot.shapr <- function(x,

--- a/R/shapley.R
+++ b/R/shapley.R
@@ -86,6 +86,7 @@ weight_matrix <- function(X, normalize_W_weights = TRUE) {
 #' @author Nikolai Sellereite
 #'
 #' @examples
+#' if (requireNamespace("MASS", quietly = TRUE)) {
 #' # Load example data
 #' data("Boston", package = "MASS")
 #' df <- Boston
@@ -118,6 +119,7 @@ weight_matrix <- function(X, normalize_W_weights = TRUE) {
 #'
 #' print(nrow(explainer$X))
 #' # 16 (which equals 2^4)
+#' }
 shapr <- function(x,
                   model,
                   n_combinations = NULL,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -3,7 +3,7 @@
 
 * Got an email fran CRAN that shapr gave ERROR due to ERROR in package under Suggests (xgboost). Even though the xgboost issue was fixed in time, shapr was taken off CRAN due to packages under Suggests not being used conditionally in tests and examples. This patch fixes this issue using
 ```
-if(requireNamespace("pkgname"))
+if(requireNamespace("pkgname", quietly = TRUE))
 ```
 and checked to run fine without Suggested packages through
 ```
@@ -17,7 +17,11 @@ devtools::check(vignettes = FALSE, env_vars=c(`_R_CHECK_DEPENDS_ONLY_` = "true")
 * GitHub Actions (ubuntu-16.04): R 4.0, 3.6, 3.5
 * win-builder (x86_64-w64-mingw32): R 4.0, 3.6, R-devel
 * local Ubuntu 18.04: R 3.6
-* local Windows 10: R 4.0.2, R-devel (2020-08-04 r78971)
+* local Windows 10: R 4.0
+* R-hub (windows-x86_64-devel): R-devel
+* R-hub (ubuntu-gcc-release): R-release
+* R-hub (fedora-gcc-devel): R-devel
+* R-hub (macos-highsierra-release-cran): R-release
 
 ## R CMD check results
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,37 +1,49 @@
 
-# Patch for shapr 0.1.2
+# Patch for shapr 0.1.3
 
-* Fixes the installation error on Solaris for version 0.1.2 as described in
-https://cran.r-project.org/web/checks/check_results_shapr.html. Checks using
-rhub::check_on_solaris() indicates the issue is fixed in this release.
+* Got an email fran CRAN that shapr gave ERROR due to ERROR in package under Suggests (xgboost). Even though the xgboost issue was fixed in time, shapr was taken off CRAN due to packages under Suggests not being used conditionally in tests and examples. This patch fixes this issue using
+```
+if(requireNamespace("pkgname"))
+```
+and checked to run fine without Suggested packages through
+```
+devtools::check(vignettes = FALSE, env_vars=c(`_R_CHECK_DEPENDS_ONLY_` = "true"))
+```
+
 
 ## Test environments
 
-* GitHub Actions (macOS-latest): R 4.0.2
-* GitHub Actions (windows-latest): R 4.0.2
-* GitHub Actions (ubuntu-16.04): R 4.0.2, 3.6.3, 3.5.3
-* win-builder (x86_64-w64-mingw32): R 4.0.2, 3.6.3, R-devel (2020-08-23 r79071)
-* local Ubuntu 18.04: R 3.6.3
+* GitHub Actions (windows-latest): R 4.0
+* GitHub Actions (ubuntu-16.04): R 4.0, 3.6, 3.5
+* win-builder (x86_64-w64-mingw32): R 4.0, 3.6, R-devel
+* local Ubuntu 18.04: R 3.6
 * local Windows 10: R 4.0.2, R-devel (2020-08-04 r78971)
 
 ## R CMD check results
 
 There were no ERRORs or WARNINGs.
 
-There was 2 NOTES:
+There was 1 NOTE:
 
 * checking CRAN incoming feasibility ... NOTE
-Maintainer: 'Martin Jullum <Martin.Jullum@nr.no>'
+Maintainer: ‘Martin Jullum <Martin.Jullum@nr.no>’
 
-Days since last update: 0
+New submission
 
-> This is a patch for the current installation error on Solaris
+Package was archived on CRAN
 
-* checking for future file timestamps ... NOTE
-  unable to verify current time
+Possibly mis-spelled words in DESCRIPTION:
+  Aas (9:16)
+  Jullum (9:21)
+  Løland (9:32)
+  Shapley (3:53, 6:15, 7:84, 10:72)
 
-> This is a known issue with the worldclockapi.com currently being down
-  (https://stackoverflow.com/questions/63613301/r-cmd-check-note-unable-to-verify-current-time)
+CRAN repository db overrides:
+  X-CRAN-Comment: Archived on 2021-01-20 as check problems were not
+    corrected in time.
+
+> This is a patch for the version that was taken off CRAN.
+
 
 ## Downstream dependencies
 There are currently no downstream dependencies for this package.

--- a/man/explain.Rd
+++ b/man/explain.Rd
@@ -139,6 +139,7 @@ if you condition on more than 5 features this can be done by simply passing
 when conditioning on \code{i} features.
 }
 \examples{
+if (requireNamespace("MASS", quietly = TRUE)) {
 # Load example data
 data("Boston", package = "MASS")
 
@@ -172,7 +173,10 @@ explain4 <- explain(x_test, explainer, approach = approach, prediction_zero = p,
 print(explain1$dt)
 
 # Plot the results
+if (requireNamespace("ggplot2", quietly = TRUE)) {
 plot(explain1)
+}
+}
 }
 \author{
 Camilla Lingjaerde, Nikolai Sellereite

--- a/man/features.Rd
+++ b/man/features.Rd
@@ -35,6 +35,7 @@ features(x, cnms, feature_labels = NULL)
 Fetches feature labels from a given model object
 }
 \examples{
+if (requireNamespace("MASS", quietly = TRUE)) {
 # Load example data
 data("Boston", package = "MASS")
 # Split data into test- and training data
@@ -46,5 +47,6 @@ cnms <- c("lstat", "rm", "dis", "indus")
 
 # Checking that features used by the model corresponds to cnms
 features(x = model, cnms = cnms, feature_labels = NULL)
+}
 }
 \keyword{internal}

--- a/man/model_type.Rd
+++ b/man/model_type.Rd
@@ -41,6 +41,7 @@ See \code{\link{predict_model}} for more information about
 what type of models \code{shapr} currently support.
 }
 \examples{
+if (requireNamespace("MASS", quietly = TRUE)) {
 # Load example data
 data("Boston", package = "MASS")
 # Split data into test- and training data
@@ -50,5 +51,6 @@ model <- lm(medv ~ lstat + rm + dis + indus, data = x_train)
 
 # Writing out the defined model type of the object
 model_type(x = model)
+}
 }
 \keyword{internal}

--- a/man/plot.shapr.Rd
+++ b/man/plot.shapr.Rd
@@ -41,6 +41,7 @@ See \code{vignette("understanding_shapr", package = "shapr")} for an example of
 how you should use the function.
 }
 \examples{
+if (requireNamespace("MASS", quietly = TRUE)) {
 #' # Load example data
 data("Boston", package = "MASS")
 
@@ -64,8 +65,11 @@ explanation <- explain(x_test,
                       prediction_zero = p,
                       n_samples = 1e2)
 
+if (requireNamespace("ggplot2", quietly = TRUE)) {
 # Plot the explantion (this function)
 plot(explanation)
+}
+}
 
 }
 \author{

--- a/man/predict_model.Rd
+++ b/man/predict_model.Rd
@@ -61,6 +61,7 @@ For more details on how to use a custom model see the package vignette: \cr
 \code{vignette("understanding_shapr", package = "shapr")}
 }
 \examples{
+if (requireNamespace("MASS", quietly = TRUE)) {
 # Load example data
 data("Boston", package = "MASS")
 # Split data into test- and training data
@@ -71,6 +72,7 @@ model <- lm(medv ~ lstat + rm + dis + indus, data = x_train)
 
 # Predicting for a model with a standardized format
 predict_model(x = model, newdata = x_test)
+}
 }
 \author{
 Martin Jullum

--- a/man/shapr.Rd
+++ b/man/shapr.Rd
@@ -43,6 +43,7 @@ model) and \code{n_combinations} is also present in the returned object.
 Create an explainer object with Shapley weights for test data.
 }
 \examples{
+if (requireNamespace("MASS", quietly = TRUE)) {
 # Load example data
 data("Boston", package = "MASS")
 df <- Boston
@@ -75,6 +76,7 @@ explainer <- shapr(df1, model, n_combinations = 1e3)
 
 print(nrow(explainer$X))
 # 16 (which equals 2^4)
+}
 }
 \author{
 Nikolai Sellereite

--- a/tests/testthat/test-a-shapley.R
+++ b/tests/testthat/test-a-shapley.R
@@ -48,8 +48,8 @@ test_that("Testing data input to shapr in shapley.R", {
       )
     )
 
-    if(requireNamespace("xgboost")){
-      l[[length(l)+1]] <-   xgboost::xgboost(
+    if (requireNamespace("xgboost")) {
+      l[[length(l) + 1]] <-   xgboost::xgboost(
         data = x_train,
         label = tail(Boston[, "medv"], -6),
         nround = 3,
@@ -57,8 +57,8 @@ test_that("Testing data input to shapr in shapley.R", {
       )
     }
 
-    if(requireNamespace("ranger")){
-      l[[length(l)+1]] <-     ranger::ranger(
+    if (requireNamespace("ranger")) {
+      l[[length(l) + 1]] <-     ranger::ranger(
         formula = formula,
         data = xy_train_full_df,
         num.trees = 50

--- a/tests/testthat/test-a-shapley.R
+++ b/tests/testthat/test-a-shapley.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(shapr)
-
 context("test-shapley.R")
 
 RNGversion(vstr = "3.5.0")
@@ -8,70 +5,80 @@ RNGversion(vstr = "3.5.0")
 test_that("Basic test functions in shapley.R", {
 
   # Load data -----------
-  data("Boston", package = "MASS")
-  x_var <- c("lstat", "rm", "dis", "indus")
-  x_train <- tail(Boston[, x_var], 50)
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    data("Boston", package = "MASS")
+    x_var <- c("lstat", "rm", "dis", "indus")
+    x_train <- tail(Boston[, x_var], 50)
 
-  # Load premade lm model. Path needs to be relative to testthat directory in the package
-  model <- readRDS("model_objects/lm_model_object.rds")
+    # Load premade lm model. Path needs to be relative to testthat directory in the package
+    model <- readRDS("model_objects/lm_model_object.rds")
 
-  # Prepare the data for explanation
-  explainer <- shapr(x_train, model)
+    # Prepare the data for explanation
+    explainer <- shapr(x_train, model)
 
-  expect_known_value(explainer, file = "test_objects/shapley_explainer_obj.rds",
-                     update = FALSE)
+    expect_known_value(explainer, file = "test_objects/shapley_explainer_obj.rds",
+                       update = FALSE)
+  }
 })
 
 
 test_that("Testing data input to shapr in shapley.R", {
 
-  data("Boston", package = "MASS")
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    data("Boston", package = "MASS")
 
-  x_var <- c("lstat", "rm", "dis", "indus")
-  x_var_sub <- x_var[1:2]
-  not_x_var <- "crim"
-  not_even_var <- "not_a_column_name"
+    x_var <- c("lstat", "rm", "dis", "indus")
+    x_var_sub <- x_var[1:2]
+    not_x_var <- "crim"
+    not_even_var <- "not_a_column_name"
 
-  x_train <- as.matrix(tail(Boston[, x_var], -6))
-  xy_train_full_df <- tail(Boston[, ], -6)
-  xy_train_missing_lstat_df <- xy_train_full_df[, !(colnames(xy_train_full_df) == "lstat")]
-  xy_train_full_df_no_colnames <- xy_train_full_df
-  colnames(xy_train_full_df_no_colnames) <- NULL
+    x_train <- as.matrix(tail(Boston[, x_var], -6))
+    xy_train_full_df <- tail(Boston[, ], -6)
+    xy_train_missing_lstat_df <- xy_train_full_df[, !(colnames(xy_train_full_df) == "lstat")]
+    xy_train_full_df_no_colnames <- xy_train_full_df
+    colnames(xy_train_full_df_no_colnames) <- NULL
 
-  # Fitting models
-  formula <- as.formula(paste0("medv ~ ", paste0(x_var, collapse = "+")))
+    # Fitting models
+    formula <- as.formula(paste0("medv ~ ", paste0(x_var, collapse = "+")))
 
-  l <- list(
-    xgboost::xgboost(
-      data = x_train,
-      label = tail(Boston[, "medv"], -6),
-      nround = 3,
-      verbose = FALSE
-    ),
-    lm(
-      formula = formula,
-      data = xy_train_full_df
-    ),
-    ranger::ranger(
-      formula = formula,
-      data = xy_train_full_df,
-      num.trees = 50
+    l <- list(
+      lm(
+        formula = formula,
+        data = xy_train_full_df
+      )
     )
-  )
 
-  for (i in seq_along(l)) {
+    if(requireNamespace("xgboost")){
+      l[[length(l)+1]] <-   xgboost::xgboost(
+        data = x_train,
+        label = tail(Boston[, "medv"], -6),
+        nround = 3,
+        verbose = FALSE
+      )
+    }
 
-    # Expect silent
-    expect_silent(shapr(xy_train_full_df, l[[i]]))
+    if(requireNamespace("ranger")){
+      l[[length(l)+1]] <-     ranger::ranger(
+        formula = formula,
+        data = xy_train_full_df,
+        num.trees = 50
+      )
+    }
 
-    # Expect message that feature_labels is ignored
-    expect_message(shapr(xy_train_full_df, l[[i]], feature_labels = x_var_sub))
-    expect_message(shapr(xy_train_full_df, l[[i]], feature_labels = x_var))
+    for (i in seq_along(l)) {
 
-    # Expect error, giving error message that indicates that x misses columns used by the model
-    expect_error(shapr(xy_train_missing_lstat_df, l[[i]]))
+      # Expect silent
+      expect_silent(shapr(xy_train_full_df, l[[i]]))
 
-    # Expect error when x_train don't have column names
-    expect_error(shapr(xy_train_full_df_no_colnames, l[[i]], feature_labels = x_var_sub))
+      # Expect message that feature_labels is ignored
+      expect_message(shapr(xy_train_full_df, l[[i]], feature_labels = x_var_sub))
+      expect_message(shapr(xy_train_full_df, l[[i]], feature_labels = x_var))
+
+      # Expect error, giving error message that indicates that x misses columns used by the model
+      expect_error(shapr(xy_train_missing_lstat_df, l[[i]]))
+
+      # Expect error when x_train don't have column names
+      expect_error(shapr(xy_train_full_df_no_colnames, l[[i]], feature_labels = x_var_sub))
+    }
   }
 })

--- a/tests/testthat/test-a-shapley.R
+++ b/tests/testthat/test-a-shapley.R
@@ -48,7 +48,7 @@ test_that("Testing data input to shapr in shapley.R", {
       )
     )
 
-    if (requireNamespace("xgboost")) {
+    if (requireNamespace("xgboost", quietly = TRUE)) {
       l[[length(l) + 1]] <-   xgboost::xgboost(
         data = x_train,
         label = tail(Boston[, "medv"], -6),
@@ -57,7 +57,7 @@ test_that("Testing data input to shapr in shapley.R", {
       )
     }
 
-    if (requireNamespace("ranger")) {
+    if (requireNamespace("ranger", quietly = TRUE)) {
       l[[length(l) + 1]] <-     ranger::ranger(
         formula = formula,
         data = xy_train_full_df,

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -165,7 +165,7 @@ test_that("Testing data input to explain in explanation.R", {
       )
     }
 
-    if(requireNamespace("mgcv")){
+    if(requireNamespace("ranger")){
       l[[length(l)+1]] <- ranger::ranger(
         formula = formula,
         data = xy_train_full_df,

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(shapr)
-
 context("test-explanation.R")
 
 # For using same Random numer generator as CircelCI (R version 3.5.x)
@@ -22,235 +19,246 @@ test_that("Test get_list_approaches", {
 test_that("Test functions in explanation.R", {
 
   # Load data -----------
-  data("Boston", package = "MASS")
-  x_var <- c("lstat", "rm", "dis", "indus")
-  y_var <- "medv"
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    data("Boston", package = "MASS")
+    x_var <- c("lstat", "rm", "dis", "indus")
+    y_var <- "medv"
 
-  y_train <- tail(Boston[, y_var], 50)
-  x_test <- as.matrix(head(Boston[, x_var], 2))
+    y_train <- tail(Boston[, y_var], 50)
+    x_test <- as.matrix(head(Boston[, x_var], 2))
 
-  # Prepare the data for explanation. Path needs to be relative to testthat directory in the package
-  explainer <- readRDS(file = "test_objects/shapley_explainer_obj.rds")
+    # Prepare the data for explanation. Path needs to be relative to testthat directory in the package
+    explainer <- readRDS(file = "test_objects/shapley_explainer_obj.rds")
 
-  # Creating list with lots of different explainer objects
-  p0 <- mean(y_train)
-  ex_list <- list()
+    # Creating list with lots of different explainer objects
+    p0 <- mean(y_train)
+    ex_list <- list()
 
-  # Ex 1: Explain predictions (gaussian)
-  ex_list[[1]] <- explain(x_test, explainer, approach = "gaussian", prediction_zero = p0)
+    # Ex 1: Explain predictions (gaussian)
+    ex_list[[1]] <- explain(x_test, explainer, approach = "gaussian", prediction_zero = p0)
 
-  # Ex 2: Explain predictions (copula)
-  ex_list[[2]] <- explain(x_test, explainer, approach = "copula", prediction_zero = p0)
+    # Ex 2: Explain predictions (copula)
+    ex_list[[2]] <- explain(x_test, explainer, approach = "copula", prediction_zero = p0)
 
-  # Ex 3: Explain predictions (empirical, independence):
-  ex_list[[3]] <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, type = "independence")
+    # Ex 3: Explain predictions (empirical, independence):
+    ex_list[[3]] <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, type = "independence")
 
-  # Ex 4: Explain predictions (empirical, fixed sigma)
-  ex_list[[4]] <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, type = "fixed_sigma")
+    # Ex 4: Explain predictions (empirical, fixed sigma)
+    ex_list[[4]] <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, type = "fixed_sigma")
 
-  # Ex 5: Explain predictions (empirical, AICc)
-  ex_list[[5]] <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, type = "AICc_each_k")
+    # Ex 5: Explain predictions (empirical, AICc)
+    ex_list[[5]] <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, type = "AICc_each_k")
 
-  # Ex 6: Explain predictions (empirical, AICc full)
-  ex_list[[6]] <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, type = "AICc_full")
+    # Ex 6: Explain predictions (empirical, AICc full)
+    ex_list[[6]] <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, type = "AICc_full")
 
-  # Ex 7: Explain combined - empirical and gaussian
-  ex_list[[7]] <- explain(x_test, explainer, approach = c("empirical", rep("gaussian", 3)), prediction_zero = p0)
+    # Ex 7: Explain combined - empirical and gaussian
+    ex_list[[7]] <- explain(x_test, explainer, approach = c("empirical", rep("gaussian", 3)), prediction_zero = p0)
 
-  # Ex 8: Explain combined II - all gaussian
-  ex_list[[8]] <- explain(x_test, explainer, approach = c(rep("gaussian", 4)), prediction_zero = p0)
+    # Ex 8: Explain combined II - all gaussian
+    ex_list[[8]] <- explain(x_test, explainer, approach = c(rep("gaussian", 4)), prediction_zero = p0)
 
-  # Ex 9: Explain combined III - all copula
-  ex_list[[9]] <- explain(x_test, explainer, approach = rep("copula", 4), prediction_zero = p0)
+    # Ex 9: Explain combined III - all copula
+    ex_list[[9]] <- explain(x_test, explainer, approach = rep("copula", 4), prediction_zero = p0)
 
-  # Ex 10: gaussian and copula XX (works with seed)
-  approach <- c(rep("gaussian", 2), rep("copula", 2))
-  ex_list[[10]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 10: gaussian and copula XX (works with seed)
+    approach <- c(rep("gaussian", 2), rep("copula", 2))
+    ex_list[[10]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Ex 11: empirical and gaussian
-  approach <- c(rep("empirical", 2), rep("gaussian", 2))
-  ex_list[[11]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 11: empirical and gaussian
+    approach <- c(rep("empirical", 2), rep("gaussian", 2))
+    ex_list[[11]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Ex 12: empirical and copula
-  approach <- c(rep("empirical", 2), rep("copula", 2))
-  ex_list[[12]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 12: empirical and copula
+    approach <- c(rep("empirical", 2), rep("copula", 2))
+    ex_list[[12]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Ex 13: copula and empirical XX (works now)
-  approach <- c(rep("copula", 2), rep("empirical", 2))
-  ex_list[[13]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 13: copula and empirical XX (works now)
+    approach <- c(rep("copula", 2), rep("empirical", 2))
+    ex_list[[13]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Ex 14: gaussian and copula XX (works with seed)
-  approach <- c(rep("gaussian", 1), rep("copula", 3))
-  ex_list[[14]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 14: gaussian and copula XX (works with seed)
+    approach <- c(rep("gaussian", 1), rep("copula", 3))
+    ex_list[[14]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Ex 15: empirical and copula
-  approach <- c(rep("empirical", 1), rep("copula", 3))
-  ex_list[[15]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 15: empirical and copula
+    approach <- c(rep("empirical", 1), rep("copula", 3))
+    ex_list[[15]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Ex 16: gaussian and empirical XX (works now)
-  approach <- c(rep("gaussian", 1), rep("empirical", 3))
-  ex_list[[16]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 16: gaussian and empirical XX (works now)
+    approach <- c(rep("gaussian", 1), rep("empirical", 3))
+    ex_list[[16]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Ex 17: gaussian and empirical XX (works now!)
-  approach <- c(rep("gaussian", 2), rep("empirical", 2))
-  ex_list[[17]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 17: gaussian and empirical XX (works now!)
+    approach <- c(rep("gaussian", 2), rep("empirical", 2))
+    ex_list[[17]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Ex 8: Explain combined II - all empirical
-  approach <- c(rep("empirical", 4))
-  ex_list[[18]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
+    # Ex 8: Explain combined II - all empirical
+    approach <- c(rep("empirical", 4))
+    ex_list[[18]] <- explain(x_test, explainer, approach = approach, prediction_zero = p0)
 
-  # Checking that all explain objects produce the same as before
-  expect_known_value(ex_list, file = "test_objects/explanation_explain_obj_list.rds",
-                     update = FALSE)
+    # Checking that all explain objects produce the same as before
+    expect_known_value(ex_list, file = "test_objects/explanation_explain_obj_list.rds",
+                       update = FALSE)
 
-  ### Additional test that only the produced shapley values are the same as before
-  fixed_explain_obj_list <- readRDS("test_objects/explanation_explain_obj_list_fixed.rds")
-  for (i in 1:length(ex_list)) {
-    expect_equal(ex_list[[i]]$dt, fixed_explain_obj_list[[i]]$dt)
+    ### Additional test that only the produced shapley values are the same as before
+    fixed_explain_obj_list <- readRDS("test_objects/explanation_explain_obj_list_fixed.rds")
+    for (i in 1:length(ex_list)) {
+      expect_equal(ex_list[[i]]$dt, fixed_explain_obj_list[[i]]$dt)
+    }
+
+
+    # Checks that an error is returned
+    expect_error(
+      explain(1, explainer, approach = "gaussian", prediction_zero = p0)
+    )
+    expect_error(
+      explain(list(), explainer, approach = "gaussian", prediction_zero = p0)
+    )
+    expect_error(
+      explain(x_test, explainer, approach = "Gaussian", prediction_zero = p0)
+    )
+    expect_error(
+      explain(x_test, explainer, approach = rep("gaussian", ncol(x_test) + 1), prediction_zero = p0)
+    )
   }
-
-
-  # Checks that an error is returned
-  expect_error(
-    explain(1, explainer, approach = "gaussian", prediction_zero = p0)
-  )
-  expect_error(
-    explain(list(), explainer, approach = "gaussian", prediction_zero = p0)
-  )
-  expect_error(
-    explain(x_test, explainer, approach = "Gaussian", prediction_zero = p0)
-  )
-  expect_error(
-    explain(x_test, explainer, approach = rep("gaussian", ncol(x_test) + 1), prediction_zero = p0)
-  )
 })
 
 test_that("Testing data input to explain in explanation.R", {
 
   # Setup for training data and explainer object
-  data("Boston", package = "MASS")
-  x_var <- c("lstat", "rm", "dis", "indus")
-  y_var <- "medv"
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    data("Boston", package = "MASS")
+    x_var <- c("lstat", "rm", "dis", "indus")
+    y_var <- "medv"
 
-  # Training data
-  x_train <- as.matrix(tail(Boston[, x_var], -6))
-  y_train <- tail(Boston[, y_var], -6)
-  xy_train_full_df <- tail(Boston[, ], -6)
+    # Training data
+    x_train <- as.matrix(tail(Boston[, x_var], -6))
+    y_train <- tail(Boston[, y_var], -6)
+    xy_train_full_df <- tail(Boston[, ], -6)
 
-  # Test data
-  x_test <- as.matrix(head(Boston[, x_var], 6))
-  x_test_full <- as.matrix(head(Boston[, ], 6))
-  x_test_reordered <- as.matrix(head(Boston[, rev(x_var)], 6))
-  xy_test_full_df <- head(Boston[, ], 6)
-  xy_test_missing_lstat_df <- xy_test_full_df[, !(colnames(xy_test_full_df) == "lstat")]
-  xy_test_full_df_no_colnames <- xy_test_full_df
-  colnames(xy_test_full_df_no_colnames) <- NULL
+    # Test data
+    x_test <- as.matrix(head(Boston[, x_var], 6))
+    x_test_full <- as.matrix(head(Boston[, ], 6))
+    x_test_reordered <- as.matrix(head(Boston[, rev(x_var)], 6))
+    xy_test_full_df <- head(Boston[, ], 6)
+    xy_test_missing_lstat_df <- xy_test_full_df[, !(colnames(xy_test_full_df) == "lstat")]
+    xy_test_full_df_no_colnames <- xy_test_full_df
+    colnames(xy_test_full_df_no_colnames) <- NULL
 
-  # Fitting models
-  formula <- as.formula(paste0("medv ~ ", paste0(x_var, collapse = "+")))
-  model1 <- xgboost::xgboost(
-    data = x_train,
-    label = y_train,
-    nround = 5,
-    verbose = FALSE
-  )
+    # Fitting models
+    formula <- as.formula(paste0("medv ~ ", paste0(x_var, collapse = "+")))
 
-  model2 <- lm(
-    formula = formula,
-    data = xy_train_full_df
-  )
-
-  model3 <- ranger::ranger(
-    formula = formula,
-    data = xy_train_full_df,
-    num.trees = 50
-  )
-
-  p0 <- mean(y_train)
-
-  # Get explainer objects
-  all_explainers <- lapply(list(model1, model2, model3), shapr, x = x_train)
-
-  # Test data
-  all_test_data <- list(
-    x_test,
-    x_test_reordered,
-    x_test_full
-  )
-
-  # Expect silent for explainer 1, using correct, reordered and full data set, then identical results
-  l <- list()
-  for (i in seq_along(all_test_data)) {
-    l[[i]] <- expect_silent(
-      explain(
-        all_test_data[[i]],
-        all_explainers[[1]],
-        approach = "empirical",
-        prediction_zero = p0,
-        n_samples = 1e2
-      )
-    )
-  }
-  for (i in 2:length(l)) {
-    expect_equal(l[[i - 1]], l[[i]])
-  }
-
-  # Expect silent for explainer 2, using correct, reordered and bigger data set, then identical results
-  l <- list()
-  for (i in seq_along(all_test_data)) {
-    l[[i]] <- expect_silent(
-      explain(
-        all_test_data[[i]],
-        all_explainers[[2]],
-        approach = "empirical",
-        prediction_zero = p0,
-        n_samples = 1e2
-      )
-    )
-  }
-  for (i in 2:length(l)) {
-    expect_equal(l[[i - 1]], l[[i]])
-  }
-
-  # Expect silent for explainer 3, using correct, reordered and bigger data set, then identical results
-  l <- list()
-  for (i in seq_along(all_test_data)) {
-    l[[i]] <- expect_silent(
-      explain(
-        all_test_data[[i]],
-        all_explainers[[3]],
-        approach = "empirical",
-        prediction_zero = p0,
-        n_samples = 1e2
-      )
-    )
-  }
-  for (i in 2:length(l)) {
-    expect_equal(l[[i - 1]], l[[i]])
-  }
-
-  for (i in seq_along(all_explainers)) {
-
-    # Expect error when test data misses used variable
-    expect_error(
-      explain(
-        xy_test_missing_lstat_df,
-        all_explainers[[i]],
-        approach = "empirical",
-        prediction_zero = p0,
-        n_samples = 1e2
+    l <- list(
+      lm(
+        formula = formula,
+        data = xy_train_full_df
       )
     )
 
-    # Expect error when test data misses column names
-    expect_error(
-      explain(
-        xy_test_full_df_no_colnames,
-        all_explainers[[i]],
-        approach = "empirical",
-        prediction_zero = p0,
-        n_samples = 1e2
+    if(requireNamespace("xgboost")){
+      l[[length(l)+1]] <- xgboost::xgboost(
+        data = x_train,
+        label = y_train,
+        nround = 5,
+        verbose = FALSE
       )
+    }
+
+    if(requireNamespace("mgcv")){
+      l[[length(l)+1]] <- ranger::ranger(
+        formula = formula,
+        data = xy_train_full_df,
+        num.trees = 50
+      )
+    }
+
+    p0 <- mean(y_train)
+
+    # Get explainer objects
+    all_explainers <- lapply(l, shapr, x = x_train)
+
+    # Test data
+    all_test_data <- list(
+      x_test,
+      x_test_reordered,
+      x_test_full
     )
+
+    # Expect silent for explainer 1, using correct, reordered and full data set, then identical results
+    l <- list()
+    for (i in seq_along(all_test_data)) {
+      l[[i]] <- expect_silent(
+        explain(
+          all_test_data[[i]],
+          all_explainers[[1]],
+          approach = "empirical",
+          prediction_zero = p0,
+          n_samples = 1e2
+        )
+      )
+    }
+    for (i in 2:length(l)) {
+      expect_equal(l[[i - 1]], l[[i]])
+    }
+
+    # Expect silent for explainer 2, using correct, reordered and bigger data set, then identical results
+    l <- list()
+    for (i in seq_along(all_test_data)) {
+      l[[i]] <- expect_silent(
+        explain(
+          all_test_data[[i]],
+          all_explainers[[2]],
+          approach = "empirical",
+          prediction_zero = p0,
+          n_samples = 1e2
+        )
+      )
+    }
+    for (i in 2:length(l)) {
+      expect_equal(l[[i - 1]], l[[i]])
+    }
+
+    # Expect silent for explainer 3, using correct, reordered and bigger data set, then identical results
+    l <- list()
+    for (i in seq_along(all_test_data)) {
+      l[[i]] <- expect_silent(
+        explain(
+          all_test_data[[i]],
+          all_explainers[[3]],
+          approach = "empirical",
+          prediction_zero = p0,
+          n_samples = 1e2
+        )
+      )
+    }
+    for (i in 2:length(l)) {
+      expect_equal(l[[i - 1]], l[[i]])
+    }
+
+    for (i in seq_along(all_explainers)) {
+
+      # Expect error when test data misses used variable
+      expect_error(
+        explain(
+          xy_test_missing_lstat_df,
+          all_explainers[[i]],
+          approach = "empirical",
+          prediction_zero = p0,
+          n_samples = 1e2
+        )
+      )
+
+      # Expect error when test data misses column names
+      expect_error(
+        explain(
+          xy_test_full_df_no_colnames,
+          all_explainers[[i]],
+          approach = "empirical",
+          prediction_zero = p0,
+          n_samples = 1e2
+        )
+      )
+    }
   }
 })

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -156,8 +156,8 @@ test_that("Testing data input to explain in explanation.R", {
       )
     )
 
-    if(requireNamespace("xgboost")){
-      l[[length(l)+1]] <- xgboost::xgboost(
+    if (requireNamespace("xgboost")) {
+      l[[length(l) + 1]] <- xgboost::xgboost(
         data = x_train,
         label = y_train,
         nround = 5,
@@ -165,8 +165,8 @@ test_that("Testing data input to explain in explanation.R", {
       )
     }
 
-    if(requireNamespace("ranger")){
-      l[[length(l)+1]] <- ranger::ranger(
+    if (requireNamespace("ranger")) {
+      l[[length(l) + 1]] <- ranger::ranger(
         formula = formula,
         data = xy_train_full_df,
         num.trees = 50

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -164,7 +164,7 @@ test_that("Testing data input to explain in explanation.R", {
       )
     )
     all_explainers <- list(
-      shapr(x_train,ll[[1]])
+      shapr(x_train, ll[[1]])
       )
 
     # Expect silent for explainer 1, using correct, reordered and full data set, then identical results
@@ -186,7 +186,7 @@ test_that("Testing data input to explain in explanation.R", {
 
     # xgboost
 
-    if (requireNamespace("xgboost")) {
+    if (requireNamespace("xgboost", quietly = TRUE)) {
       ll[[length(ll) + 1]] <- xgboost::xgboost(
         data = x_train,
         label = y_train,
@@ -194,7 +194,7 @@ test_that("Testing data input to explain in explanation.R", {
         verbose = FALSE
       )
 
-      all_explainers[[length(all_explainers) + 1]] <- shapr(x_train,ll[[length(ll)]])
+      all_explainers[[length(all_explainers) + 1]] <- shapr(x_train, ll[[length(ll)]])
 
       # Expect silent for explainer 2, using correct, reordered and bigger data set, then identical results
       l <- list()
@@ -217,14 +217,14 @@ test_that("Testing data input to explain in explanation.R", {
 
 
 
-    if (requireNamespace("ranger")) {
+    if (requireNamespace("ranger", quietly = TRUE)) {
       ll[[length(ll) + 1]] <- ranger::ranger(
         formula = formula,
         data = xy_train_full_df,
         num.trees = 50
       )
 
-      all_explainers[[length(all_explainers) + 1]] <- shapr(x_train,ll[[length(ll)]])
+      all_explainers[[length(all_explainers) + 1]] <- shapr(x_train, ll[[length(ll)]])
 
       l <- list()
       for (i in seq_along(all_test_data)) {

--- a/tests/testthat/test-features.R
+++ b/tests/testthat/test-features.R
@@ -1,5 +1,3 @@
-library(shapr)
-
 context("test-features.R")
 
 test_that("Test feature_combinations", {

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -18,14 +18,14 @@ test_that("Test predict_model (regression)", {
       stats::lm(str_formula, data = train_df),
       stats::glm(str_formula, data = train_df))
 
-    if(requireNamespace("ranger")){
-      l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df)
+    if (requireNamespace("ranger", quietly = TRUE)) {
+      l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
     }
-    if(requireNamespace("xgboost")){
-      l[[length(l)+1]] <- xgboost::xgboost(data = as.matrix(x_train), label = y_train, nrounds = 3, verbose = FALSE)
+    if (requireNamespace("xgboost", quietly = TRUE)) {
+      l[[length(l) + 1]] <- xgboost::xgboost(data = as.matrix(x_train), label = y_train, nrounds = 3, verbose = FALSE)
     }
-    if(requireNamespace("mgcv")){
-      l[[length(l)+1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
+    if (requireNamespace("mgcv", quietly = TRUE)) {
+      l[[length(l) + 1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
     }
 
     # Tests
@@ -93,14 +93,14 @@ test_that("Test predict_model (binary classification)", {
   l <- list(
     suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")))
 
-  if(requireNamespace("mgcv")){
-    l[[length(l)+1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
+  if (requireNamespace("mgcv", quietly = TRUE)) {
+    l[[length(l) + 1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
   }
-  if(requireNamespace("ranger")){
-    l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
+  if (requireNamespace("ranger", quietly = TRUE)) {
+    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
   }
-  if(requireNamespace("xgboost")){
-    l[[length(l)+1]] <- xgboost::xgboost(
+  if (requireNamespace("xgboost", quietly = TRUE)) {
+    l[[length(l) + 1]] <- xgboost::xgboost(
       data = as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -160,11 +160,11 @@ test_that("Test predict_model (binary classification)", {
   # Errors
   l <- list()
 
-  if(requireNamespace("ranger")){
-    l[[length(l)+1]] <- ranger::ranger(str_formula,data = train_df)
+  if (requireNamespace("ranger", quietly = TRUE)) {
+    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
   }
-  if(requireNamespace("xgboost")){
-    l[[length(l)+1]] <- xgboost::xgboost(
+  if (requireNamespace("xgboost", quietly = TRUE)) {
+    l[[length(l) + 1]] <- xgboost::xgboost(
       data = as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -207,19 +207,19 @@ test_that("Test predict_model (multi-classification)", {
   # List of models
   l <- list()
 
-  if(requireNamespace("ranger")){
-    l[[length(l)+1]] <-     ranger::ranger(
+  if (requireNamespace("ranger", quietly = TRUE)) {
+    l[[length(l) + 1]] <- ranger::ranger(
       str_formula,
       data = train_df
     )
-    l[[length(l)+1]] <-     ranger::ranger(
+    l[[length(l) + 1]] <- ranger::ranger(
       str_formula,
       data = train_df,
       probability = TRUE
     )
   }
-  if(requireNamespace("xgboost")){
-    l[[length(l)+1]] <-     xgboost::xgboost(
+  if (requireNamespace("xgboost", quietly = TRUE)) {
+    l[[length(l) + 1]] <- xgboost::xgboost(
       as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -227,7 +227,7 @@ test_that("Test predict_model (multi-classification)", {
       objective = "multi:softprob",
       num_class = 3
     )
-    l[[length(l)+1]] <-     xgboost::xgboost(
+    l[[length(l) + 1]] <-     xgboost::xgboost(
       as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -276,14 +276,19 @@ test_that("Test features (regression)", {
       stats::glm(str_formula, data = train_df)
     )
 
-    if(requireNamespace("ranger")){
-      l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df)
+    if (requireNamespace("ranger", quietly = TRUE)) {
+      l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
     }
-    if(requireNamespace("xgboost")){
-      l[[length(l)+1]] <- xgboost::xgboost(data = as.matrix(x_train[, x_var]), label = y_train, nrounds = 3, verbose = FALSE)
+    if (requireNamespace("xgboost", quietly = TRUE)) {
+      l[[length(l) + 1]] <- xgboost::xgboost(
+        data = as.matrix(x_train[, x_var]),
+        label = y_train,
+        nrounds = 3,
+        verbose = FALSE
+        )
     }
-    if(requireNamespace("mgcv")){
-      l[[length(l)+1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
+    if (requireNamespace("mgcv", quietly = TRUE)) {
+      l[[length(l) + 1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
     }
 
     for (i in seq_along(l)) {
@@ -312,14 +317,14 @@ test_that("Test features (binary classification)", {
   l <- list(
     suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")))
 
-  if(requireNamespace("mgcv")){
-    l[[length(l)+1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
+  if (requireNamespace("mgcv", quietly = TRUE)) {
+    l[[length(l) + 1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
   }
-  if(requireNamespace("ranger")){
-    l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
+  if (requireNamespace("ranger", quietly = TRUE)) {
+    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
   }
-  if(requireNamespace("xgboost")){
-    l[[length(l)+1]] <- xgboost::xgboost(
+  if (requireNamespace("xgboost", quietly = TRUE)) {
+    l[[length(l) + 1]] <- xgboost::xgboost(
       data = as.matrix(x_train[, x_var]),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -351,7 +356,7 @@ test_that("Test missing colnames", {
     x_test_nonames <- x_test
     colnames(x_test_nonames) <- NULL
 
-    if (requireNamespace("xgboost")) {
+    if (requireNamespace("xgboost", quietly = TRUE)) {
 
       model <- xgboost::xgboost(
         data = x_train, label = y_train, nrounds = 3, verbose = FALSE

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -18,14 +18,14 @@ test_that("Test predict_model (regression)", {
       stats::lm(str_formula, data = train_df),
       stats::glm(str_formula, data = train_df))
 
-    if (requireNamespace("ranger")) {
-      l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
+    if(requireNamespace("ranger")){
+      l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df)
     }
-    if (requireNamespace("xgboost")) {
-      l[[length(l) + 1]] <- xgboost::xgboost(data = as.matrix(x_train), label = y_train, nrounds = 3, verbose = FALSE)
+    if(requireNamespace("xgboost")){
+      l[[length(l)+1]] <- xgboost::xgboost(data = as.matrix(x_train), label = y_train, nrounds = 3, verbose = FALSE)
     }
-    if (requireNamespace("mgcv")) {
-      l[[length(l) + 1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
+    if(requireNamespace("mgcv")){
+      l[[length(l)+1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
     }
 
     # Tests
@@ -93,14 +93,14 @@ test_that("Test predict_model (binary classification)", {
   l <- list(
     suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")))
 
-  if (requireNamespace("mgcv")) {
-    l[[length(l) + 1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
+  if(requireNamespace("mgcv")){
+    l[[length(l)+1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
   }
-  if (requireNamespace("ranger")) {
-    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
+  if(requireNamespace("ranger")){
+    l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
   }
-  if (requireNamespace("xgboost")) {
-    l[[length(l) + 1]] <- xgboost::xgboost(
+  if(requireNamespace("xgboost")){
+    l[[length(l)+1]] <- xgboost::xgboost(
       data = as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -160,11 +160,11 @@ test_that("Test predict_model (binary classification)", {
   # Errors
   l <- list()
 
-  if (requireNamespace("ranger")) {
-    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
+  if(requireNamespace("ranger")){
+    l[[length(l)+1]] <- ranger::ranger(str_formula,data = train_df)
   }
-  if (requireNamespace("xgboost")) {
-    l[[length(l) + 1]] <- xgboost::xgboost(
+  if(requireNamespace("xgboost")){
+    l[[length(l)+1]] <- xgboost::xgboost(
       data = as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -207,19 +207,19 @@ test_that("Test predict_model (multi-classification)", {
   # List of models
   l <- list()
 
-  if (requireNamespace("ranger")) {
-    l[[length(l) + 1]] <-     ranger::ranger(
+  if(requireNamespace("ranger")){
+    l[[length(l)+1]] <-     ranger::ranger(
       str_formula,
       data = train_df
     )
-    l[[length(l) + 1]] <-     ranger::ranger(
+    l[[length(l)+1]] <-     ranger::ranger(
       str_formula,
       data = train_df,
       probability = TRUE
     )
   }
-  if (requireNamespace("xgboost")) {
-    l[[length(l) + 1]] <-     xgboost::xgboost(
+  if(requireNamespace("xgboost")){
+    l[[length(l)+1]] <-     xgboost::xgboost(
       as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -227,7 +227,7 @@ test_that("Test predict_model (multi-classification)", {
       objective = "multi:softprob",
       num_class = 3
     )
-    l[[length(l) + 1]] <-     xgboost::xgboost(
+    l[[length(l)+1]] <-     xgboost::xgboost(
       as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -276,19 +276,14 @@ test_that("Test features (regression)", {
       stats::glm(str_formula, data = train_df)
     )
 
-    if (requireNamespace("ranger")) {
-      l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
+    if(requireNamespace("ranger")){
+      l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df)
     }
-    if (requireNamespace("xgboost")) {
-      l[[length(l) + 1]] <- xgboost::xgboost(
-        data = as.matrix(x_train[, x_var]),
-        label = y_train,
-        nrounds = 3,
-        verbose = FALSE
-        )
+    if(requireNamespace("xgboost")){
+      l[[length(l)+1]] <- xgboost::xgboost(data = as.matrix(x_train[, x_var]), label = y_train, nrounds = 3, verbose = FALSE)
     }
-    if (requireNamespace("mgcv")) {
-      l[[length(l) + 1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
+    if(requireNamespace("mgcv")){
+      l[[length(l)+1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
     }
 
     for (i in seq_along(l)) {
@@ -317,14 +312,14 @@ test_that("Test features (binary classification)", {
   l <- list(
     suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")))
 
-  if (requireNamespace("mgcv")) {
-    l[[length(l) + 1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
+  if(requireNamespace("mgcv")){
+    l[[length(l)+1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
   }
-  if (requireNamespace("ranger")) {
-    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
+  if(requireNamespace("ranger")){
+    l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
   }
-  if (requireNamespace("xgboost")) {
-    l[[length(l) + 1]] <- xgboost::xgboost(
+  if(requireNamespace("xgboost")){
+    l[[length(l)+1]] <- xgboost::xgboost(
       data = as.matrix(x_train[, x_var]),
       label = as.integer(y_train) - 1,
       nrounds = 2,

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -18,14 +18,14 @@ test_that("Test predict_model (regression)", {
       stats::lm(str_formula, data = train_df),
       stats::glm(str_formula, data = train_df))
 
-    if(requireNamespace("ranger")){
-      l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df)
+    if (requireNamespace("ranger")) {
+      l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
     }
-    if(requireNamespace("xgboost")){
-      l[[length(l)+1]] <- xgboost::xgboost(data = as.matrix(x_train), label = y_train, nrounds = 3, verbose = FALSE)
+    if (requireNamespace("xgboost")) {
+      l[[length(l) + 1]] <- xgboost::xgboost(data = as.matrix(x_train), label = y_train, nrounds = 3, verbose = FALSE)
     }
-    if(requireNamespace("mgcv")){
-      l[[length(l)+1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
+    if (requireNamespace("mgcv")) {
+      l[[length(l) + 1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
     }
 
     # Tests
@@ -93,14 +93,14 @@ test_that("Test predict_model (binary classification)", {
   l <- list(
     suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")))
 
-  if(requireNamespace("mgcv")){
-    l[[length(l)+1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
+  if (requireNamespace("mgcv")) {
+    l[[length(l) + 1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
   }
-  if(requireNamespace("ranger")){
-    l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
+  if (requireNamespace("ranger")) {
+    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
   }
-  if(requireNamespace("xgboost")){
-    l[[length(l)+1]] <- xgboost::xgboost(
+  if (requireNamespace("xgboost")) {
+    l[[length(l) + 1]] <- xgboost::xgboost(
       data = as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -160,11 +160,11 @@ test_that("Test predict_model (binary classification)", {
   # Errors
   l <- list()
 
-  if(requireNamespace("ranger")){
-    l[[length(l)+1]] <- ranger::ranger(str_formula,data = train_df)
+  if (requireNamespace("ranger")) {
+    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
   }
-  if(requireNamespace("xgboost")){
-    l[[length(l)+1]] <- xgboost::xgboost(
+  if (requireNamespace("xgboost")) {
+    l[[length(l) + 1]] <- xgboost::xgboost(
       data = as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -207,19 +207,19 @@ test_that("Test predict_model (multi-classification)", {
   # List of models
   l <- list()
 
-  if(requireNamespace("ranger")){
-    l[[length(l)+1]] <-     ranger::ranger(
+  if (requireNamespace("ranger")) {
+    l[[length(l) + 1]] <-     ranger::ranger(
       str_formula,
       data = train_df
     )
-    l[[length(l)+1]] <-     ranger::ranger(
+    l[[length(l) + 1]] <-     ranger::ranger(
       str_formula,
       data = train_df,
       probability = TRUE
     )
   }
-  if(requireNamespace("xgboost")){
-    l[[length(l)+1]] <-     xgboost::xgboost(
+  if (requireNamespace("xgboost")) {
+    l[[length(l) + 1]] <-     xgboost::xgboost(
       as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -227,7 +227,7 @@ test_that("Test predict_model (multi-classification)", {
       objective = "multi:softprob",
       num_class = 3
     )
-    l[[length(l)+1]] <-     xgboost::xgboost(
+    l[[length(l) + 1]] <-     xgboost::xgboost(
       as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -276,14 +276,19 @@ test_that("Test features (regression)", {
       stats::glm(str_formula, data = train_df)
     )
 
-    if(requireNamespace("ranger")){
-      l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df)
+    if (requireNamespace("ranger")) {
+      l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df)
     }
-    if(requireNamespace("xgboost")){
-      l[[length(l)+1]] <- xgboost::xgboost(data = as.matrix(x_train[, x_var]), label = y_train, nrounds = 3, verbose = FALSE)
+    if (requireNamespace("xgboost")) {
+      l[[length(l) + 1]] <- xgboost::xgboost(
+        data = as.matrix(x_train[, x_var]),
+        label = y_train,
+        nrounds = 3,
+        verbose = FALSE
+        )
     }
-    if(requireNamespace("mgcv")){
-      l[[length(l)+1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
+    if (requireNamespace("mgcv")) {
+      l[[length(l) + 1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
     }
 
     for (i in seq_along(l)) {
@@ -312,14 +317,14 @@ test_that("Test features (binary classification)", {
   l <- list(
     suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")))
 
-  if(requireNamespace("mgcv")){
-    l[[length(l)+1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
+  if (requireNamespace("mgcv")) {
+    l[[length(l) + 1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
   }
-  if(requireNamespace("ranger")){
-    l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
+  if (requireNamespace("ranger")) {
+    l[[length(l) + 1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
   }
-  if(requireNamespace("xgboost")){
-    l[[length(l)+1]] <- xgboost::xgboost(
+  if (requireNamespace("xgboost")) {
+    l[[length(l) + 1]] <- xgboost::xgboost(
       data = as.matrix(x_train[, x_var]),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -351,7 +356,7 @@ test_that("Test missing colnames", {
     x_test_nonames <- x_test
     colnames(x_test_nonames) <- NULL
 
-    if(requireNamespace("xgboost")){
+    if (requireNamespace("xgboost")) {
 
       model <- xgboost::xgboost(
         data = x_train, label = y_train, nrounds = 3, verbose = FALSE

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -1,75 +1,82 @@
-library(shapr)
-library(testthat)
-
 context("test-models.R")
 
 test_that("Test predict_model (regression)", {
 
   # Data -----------
-  data("Boston", package = "MASS")
-  x_var <- c("lstat", "rm", "dis", "indus")
-  y_var <- "medv"
-  x_train <- tail(Boston[, x_var], -6)
-  y_train <- tail(Boston[, y_var], -6)
-  x_test <- head(Boston[, x_var], 6)
-  str_formula <- "y_train ~ lstat + rm + dis + indus"
-  train_df <- cbind(y_train, x_train)
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    data("Boston", package = "MASS")
+    x_var <- c("lstat", "rm", "dis", "indus")
+    y_var <- "medv"
+    x_train <- tail(Boston[, x_var], -6)
+    y_train <- tail(Boston[, y_var], -6)
+    x_test <- head(Boston[, x_var], 6)
+    str_formula <- "y_train ~ lstat + rm + dis + indus"
+    train_df <- cbind(y_train, x_train)
 
-  # List of models
-  l <- list(
-    stats::lm(str_formula, data = train_df),
-    stats::glm(str_formula, data = train_df),
-    ranger::ranger(str_formula, data = train_df),
-    xgboost::xgboost(data = as.matrix(x_train), label = y_train, nrounds = 3, verbose = FALSE),
-    mgcv::gam(as.formula(str_formula), data = train_df)
-  )
+    # List of models
+    l <- list(
+      stats::lm(str_formula, data = train_df),
+      stats::glm(str_formula, data = train_df))
 
-  # Tests
-  for (i in seq_along(l)) {
+    if(requireNamespace("ranger")){
+      l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df)
+    }
+    if(requireNamespace("xgboost")){
+      l[[length(l)+1]] <- xgboost::xgboost(data = as.matrix(x_train), label = y_train, nrounds = 3, verbose = FALSE)
+    }
+    if(requireNamespace("mgcv")){
+      l[[length(l)+1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
+    }
 
-    # Input equals data.frame
-    expect_true(
-      is.vector(predict_model(l[[i]], x_test))
-    )
-    expect_true(
-      is.atomic(predict_model(l[[i]], x_test))
-    )
-    expect_true(
-      is.double(predict_model(l[[i]], x_test))
-    )
-    expect_true(
-      length(predict_model(l[[i]], x_test)) == nrow(x_test)
-    )
+    # Tests
+    for (i in seq_along(l)) {
 
-    # Input equals matrix
-    expect_true(
-      is.double(predict_model(l[[i]], as.matrix(x_test)))
-    )
-    expect_true(
-      is.atomic(predict_model(l[[i]], as.matrix(x_test)))
-    )
-    expect_true(
-      is.vector(predict_model(l[[i]], as.matrix(x_test)))
-    )
-    expect_true(
-      length(predict_model(l[[i]], as.matrix(x_test))) == nrow(x_test)
-    )
+      # Input equals data.frame
+      expect_true(
+        is.vector(predict_model(l[[i]], x_test))
+      )
+      expect_true(
+        is.atomic(predict_model(l[[i]], x_test))
+      )
+      expect_true(
+        is.double(predict_model(l[[i]], x_test))
+      )
+      expect_true(
+        length(predict_model(l[[i]], x_test)) == nrow(x_test)
+      )
 
-    # Check that output is equal
-    expect_equal(
-      predict_model(l[[i]], x_test), predict_model(l[[i]], as.matrix(x_test))
-    )
+      # Input equals matrix
+      expect_true(
+        is.double(predict_model(l[[i]], as.matrix(x_test)))
+      )
+      expect_true(
+        is.atomic(predict_model(l[[i]], as.matrix(x_test)))
+      )
+      expect_true(
+        is.vector(predict_model(l[[i]], as.matrix(x_test)))
+      )
+      expect_true(
+        length(predict_model(l[[i]], as.matrix(x_test))) == nrow(x_test)
+      )
 
-    # Check model type
-    expect_equal(
-      model_type(l[[i]]), "regression"
-    )
+      # Check that output is equal
+      expect_equal(
+        predict_model(l[[i]], x_test), predict_model(l[[i]], as.matrix(x_test))
+      )
+
+      # Check model type
+      expect_equal(
+        model_type(l[[i]]), "regression"
+      )
+    }
+
   }
 })
 
 test_that("Test predict_model (binary classification)", {
 
   # Data -----------
+
   data("iris", package = "datasets")
   x_var <- c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width")
   y_var <- "Species"
@@ -84,17 +91,23 @@ test_that("Test predict_model (binary classification)", {
 
   # List of models
   l <- list(
-    suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")),
-    suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial")),
-    ranger::ranger(str_formula, data = train_df, probability = TRUE),
-    xgboost::xgboost(
+    suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")))
+
+  if(requireNamespace("mgcv")){
+    l[[length(l)+1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
+  }
+  if(requireNamespace("ranger")){
+    l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
+  }
+  if(requireNamespace("xgboost")){
+    l[[length(l)+1]] <- xgboost::xgboost(
       data = as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
       verbose = FALSE,
       objective = "binary:logistic"
     )
-  )
+  }
 
   # Tests
   for (i in seq_along(l)) {
@@ -145,19 +158,19 @@ test_that("Test predict_model (binary classification)", {
   }
 
   # Errors
-  l <- list(
-    ranger::ranger(
-      str_formula,
-      data = train_df
-    ),
-    xgboost::xgboost(
+  l <- list()
+
+  if(requireNamespace("ranger")){
+    l[[length(l)+1]] <- ranger::ranger(str_formula,data = train_df)
+  }
+  if(requireNamespace("xgboost")){
+    l[[length(l)+1]] <- xgboost::xgboost(
       data = as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
       verbose = FALSE,
-      objective = "reg:logistic"
-    )
-  )
+      objective = "reg:logistic")
+  }
 
   # Tests
   for (i in seq_along(l)) {
@@ -192,25 +205,29 @@ test_that("Test predict_model (multi-classification)", {
   train_df <- cbind(y_train, x_train)
 
   # List of models
-  l <- list(
-    ranger::ranger(
+  l <- list()
+
+  if(requireNamespace("ranger")){
+    l[[length(l)+1]] <-     ranger::ranger(
       str_formula,
       data = train_df
-    ),
-    ranger::ranger(
+    )
+    l[[length(l)+1]] <-     ranger::ranger(
       str_formula,
       data = train_df,
       probability = TRUE
-    ),
-    xgboost::xgboost(
+    )
+  }
+  if(requireNamespace("xgboost")){
+    l[[length(l)+1]] <-     xgboost::xgboost(
       as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
       verbose = FALSE,
       objective = "multi:softprob",
       num_class = 3
-    ),
-    xgboost::xgboost(
+    )
+    l[[length(l)+1]] <-     xgboost::xgboost(
       as.matrix(x_train),
       label = as.integer(y_train) - 1,
       nrounds = 2,
@@ -218,7 +235,8 @@ test_that("Test predict_model (multi-classification)", {
       objective = "multi:softmax",
       num_class = 3
     )
-  )
+  }
+
 
   # Tests
   for (i in seq_along(l)) {
@@ -243,25 +261,35 @@ test_that("Test predict_model (multi-classification)", {
 test_that("Test features (regression)", {
 
   # Data -----------
-  data("Boston", package = "MASS")
-  x_var <- c("lstat", "rm", "dis", "indus")
-  y_var <- "medv"
-  x_train <- tail(Boston, -6)
-  y_train <- tail(Boston[, y_var], -6)
-  str_formula <- "y_train ~ lstat + rm + dis + indus"
-  train_df <- cbind(y_train, x_train)
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    data("Boston", package = "MASS")
+    x_var <- c("lstat", "rm", "dis", "indus")
+    y_var <- "medv"
+    x_train <- tail(Boston, -6)
+    y_train <- tail(Boston[, y_var], -6)
+    str_formula <- "y_train ~ lstat + rm + dis + indus"
+    train_df <- cbind(y_train, x_train)
 
-  # List of models
-  l <- list(
-    stats::lm(str_formula, data = train_df),
-    stats::glm(str_formula, data = train_df),
-    ranger::ranger(str_formula, data = train_df),
-    xgboost::xgboost(data = as.matrix(x_train[, x_var]), label = y_train, nrounds = 3, verbose = FALSE),
-    mgcv::gam(as.formula(str_formula), data = train_df)
-  )
+    # List of models
+    l <- list(
+      stats::lm(str_formula, data = train_df),
+      stats::glm(str_formula, data = train_df)
+    )
 
-  for (i in seq_along(l)) {
-    expect_equal(features(l[[i]], cnms = colnames(train_df)), x_var)
+    if(requireNamespace("ranger")){
+      l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df)
+    }
+    if(requireNamespace("xgboost")){
+      l[[length(l)+1]] <- xgboost::xgboost(data = as.matrix(x_train[, x_var]), label = y_train, nrounds = 3, verbose = FALSE)
+    }
+    if(requireNamespace("mgcv")){
+      l[[length(l)+1]] <- mgcv::gam(as.formula(str_formula), data = train_df)
+    }
+
+    for (i in seq_along(l)) {
+      expect_equal(features(l[[i]], cnms = colnames(train_df)), x_var)
+    }
+
   }
 
 })
@@ -282,17 +310,23 @@ test_that("Test features (binary classification)", {
 
   # List of models
   l <- list(
-    suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")),
-    suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial")),
-    ranger::ranger(str_formula, data = train_df, probability = TRUE),
-    xgboost::xgboost(
+    suppressWarnings(stats::glm(str_formula, data = train_df, family = "binomial")))
+
+  if(requireNamespace("mgcv")){
+    l[[length(l)+1]] <- suppressWarnings(mgcv::gam(as.formula(str_formula), data = train_df, family = "binomial"))
+  }
+  if(requireNamespace("ranger")){
+    l[[length(l)+1]] <- ranger::ranger(str_formula, data = train_df, probability = TRUE)
+  }
+  if(requireNamespace("xgboost")){
+    l[[length(l)+1]] <- xgboost::xgboost(
       data = as.matrix(x_train[, x_var]),
       label = as.integer(y_train) - 1,
       nrounds = 2,
       verbose = FALSE,
       objective = "binary:logistic"
     )
-  )
+  }
 
   for (i in seq_along(l)) {
     expect_equal(features(l[[i]], cnms = colnames(train_df)), x_var)
@@ -304,44 +338,48 @@ test_that("Test features (binary classification)", {
 test_that("Test missing colnames", {
 
   # Data -----------
-  data("Boston", package = "MASS")
-  x_var <- c("lstat", "rm", "dis", "indus")
-  y_var <- "medv"
-  x_train <- as.matrix(tail(Boston[, x_var], -6))
-  y_train <- tail(Boston[, y_var], -6)
-  x_test <- as.matrix(head(Boston[, x_var]))
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    data("Boston", package = "MASS")
+    x_var <- c("lstat", "rm", "dis", "indus")
+    y_var <- "medv"
+    x_train <- as.matrix(tail(Boston[, x_var], -6))
+    y_train <- tail(Boston[, y_var], -6)
+    x_test <- as.matrix(head(Boston[, x_var]))
 
-  x_train_nonames <- x_train
-  colnames(x_train_nonames) <- NULL
-  x_test_nonames <- x_test
-  colnames(x_test_nonames) <- NULL
+    x_train_nonames <- x_train
+    colnames(x_train_nonames) <- NULL
+    x_test_nonames <- x_test
+    colnames(x_test_nonames) <- NULL
 
-  model <- xgboost::xgboost(
-    data = x_train, label = y_train, nrounds = 3, verbose = FALSE
-    )
-  model_nonames <- xgboost::xgboost(
-    data = x_train_nonames, label = y_train, nrounds = 3, verbose = FALSE
-  )
+    if(requireNamespace("xgboost")){
 
-  # missing colnames in model
-  expect_error(shapr(model_nonames, x_train))
+      model <- xgboost::xgboost(
+        data = x_train, label = y_train, nrounds = 3, verbose = FALSE
+      )
+      model_nonames <- xgboost::xgboost(
+        data = x_train_nonames, label = y_train, nrounds = 3, verbose = FALSE
+      )
 
-  # missing colnames in training data
-  expect_error(shapr(model, x_train_nonames))
+      # missing colnames in model
+      expect_error(shapr(model_nonames, x_train))
 
-  # missing colnames in both model and training data
-  expect_error(shapr(model_nonames, x_train_nonames))
+      # missing colnames in training data
+      expect_error(shapr(model, x_train_nonames))
 
-  # missing colnames in test data
-  explain <- shapr(x_train, model)
-  p <- mean(y_train)
-  expect_error(
-    explain(
-      x_test_nonames,
-      approach = "empirical",
-      explainer = explainer,
-      prediction_zero = p
-    )
-  )
+      # missing colnames in both model and training data
+      expect_error(shapr(model_nonames, x_train_nonames))
 
+      # missing colnames in test data
+      explain <- shapr(x_train, model)
+      p <- mean(y_train)
+      expect_error(
+        explain(
+          x_test_nonames,
+          approach = "empirical",
+          explainer = explainer,
+          prediction_zero = p
+        )
+      )
+    }
+  }
 })

--- a/tests/testthat/test-observations.R
+++ b/tests/testthat/test-observations.R
@@ -1,56 +1,55 @@
-library(shapr)
-
 context("test-observations.R")
 
 test_that("Test observation_impute", {
 
-  # Examples
-  n <- 20
-  m <- 2
-  sigma <- cov(matrix(MASS::mvrnorm(m * n, 0, 1), nrow = n))
-  x_train <- as.matrix(MASS::mvrnorm(n, mu = rep(0, m), Sigma = sigma), ncol = m)
-  x_test <- t(as.matrix(MASS::mvrnorm(1, mu = rep(0, m), sigma)))
-  colnames(x_train) <- colnames(x_test) <- paste0("X", seq(m))
-  S <- matrix(c(1, 0, 0, 1), nrow = m)
-  W_kernel <- matrix(rnorm(n * ncol(S), mean = 1 / n, sd = 1 / n^2), nrow = n)
-  r <- observation_impute(W_kernel, S, x_train, x_test)
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    # Examples
+    n <- 20
+    m <- 2
+    sigma <- cov(matrix(MASS::mvrnorm(m * n, 0, 1), nrow = n))
+    x_train <- as.matrix(MASS::mvrnorm(n, mu = rep(0, m), Sigma = sigma), ncol = m)
+    x_test <- t(as.matrix(MASS::mvrnorm(1, mu = rep(0, m), sigma)))
+    colnames(x_train) <- colnames(x_test) <- paste0("X", seq(m))
+    S <- matrix(c(1, 0, 0, 1), nrow = m)
+    W_kernel <- matrix(rnorm(n * ncol(S), mean = 1 / n, sd = 1 / n^2), nrow = n)
+    r <- observation_impute(W_kernel, S, x_train, x_test)
 
-  # Test the default argument n_samples
-  expect_equal(
-    observation_impute(W_kernel, S, x_train, x_test, n_samples = 1e3),
-    observation_impute(W_kernel, S, x_train, x_test)
-  )
+    # Test the default argument n_samples
+    expect_equal(
+      observation_impute(W_kernel, S, x_train, x_test, n_samples = 1e3),
+      observation_impute(W_kernel, S, x_train, x_test)
+    )
 
-  # Test the default argument w_threshold
-  expect_equal(
-    observation_impute(W_kernel, S, x_train, x_test, w_threshold = .7),
-    observation_impute(W_kernel, S, x_train, x_test)
-  )
+    # Test the default argument w_threshold
+    expect_equal(
+      observation_impute(W_kernel, S, x_train, x_test, w_threshold = .7),
+      observation_impute(W_kernel, S, x_train, x_test)
+    )
 
-  # Test that w_threshold reduces number of rows
-  expect_true(
-    nrow(observation_impute(W_kernel, S, x_train, x_test, w_threshold = .7)) >
-    nrow(observation_impute(W_kernel, S, x_train, x_test, w_threshold = 0.5))
-  )
+    # Test that w_threshold reduces number of rows
+    expect_true(
+      nrow(observation_impute(W_kernel, S, x_train, x_test, w_threshold = .7)) >
+        nrow(observation_impute(W_kernel, S, x_train, x_test, w_threshold = 0.5))
+    )
 
-  # Test that n_samples reduces number of rows
-  expect_true(
-    nrow(observation_impute(W_kernel, S, x_train, x_test)) >
-    nrow(observation_impute(W_kernel, S, x_train, x_test, n_samples = 10))
-  )
+    # Test that n_samples reduces number of rows
+    expect_true(
+      nrow(observation_impute(W_kernel, S, x_train, x_test)) >
+        nrow(observation_impute(W_kernel, S, x_train, x_test, n_samples = 10))
+    )
 
-  # Tests error
-  expect_error(observation_impute(1, S, x_train, x_test))
-  expect_error(observation_impute(W_kernel, 1, x_train, x_test))
-  expect_error(observation_impute(W_kernel, tail(S, -1), x_train, x_test))
-  expect_error(observation_impute(tail(W_kernel, -1), S, x_train, x_test))
+    # Tests error
+    expect_error(observation_impute(1, S, x_train, x_test))
+    expect_error(observation_impute(W_kernel, 1, x_train, x_test))
+    expect_error(observation_impute(W_kernel, tail(S, -1), x_train, x_test))
+    expect_error(observation_impute(tail(W_kernel, -1), S, x_train, x_test))
 
-  # Test single result
-  cnms <- c(colnames(x_train), "id_combination", "w")
-  expect_true(data.table::is.data.table(r))
-  expect_true(ncol(r) == m + 2)
-  expect_true(all(colnames(r) == cnms))
-  expect_true(all(unlist(lapply(r, is.numeric))))
-  expect_true(is.integer(r$id_combination))
-
+    # Test single result
+    cnms <- c(colnames(x_train), "id_combination", "w")
+    expect_true(data.table::is.data.table(r))
+    expect_true(ncol(r) == m + 2)
+    expect_true(all(colnames(r) == cnms))
+    expect_true(all(unlist(lapply(r, is.numeric))))
+    expect_true(is.integer(r$id_combination))
+  }
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -2,7 +2,7 @@ context("test-plot.R")
 
 test_that("Test plot.shapr", {
 
-  if (requireNamespace("ggplot2")) {
+  if (requireNamespace("ggplot2", quietly = TRUE)) {
 
     # Example -----------
     x <- matrix(c(4.98, 9.14, 4.03, 2.94, 5.33,

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,46 +1,47 @@
-library(shapr)
-
 context("test-plot.R")
 
 test_that("Test plot.shapr", {
 
-  # Example -----------
-  x <- matrix(c(4.98, 9.14, 4.03, 2.94, 5.33,
-                6.575, 6.421, 7.185, 6.998, 7.147,
-                4.0900, 4.9671, 4.9671, 6.0622, 6.0622,
-                2.31, 7.07, 7.07, 2.18, 2.18),
-              ncol = 4
-  )
+  if (requireNamespace("ggplot2")) {
 
-  colnames(x) <- c("lstat", "rm", "dis", "indus")
+    # Example -----------
+    x <- matrix(c(4.98, 9.14, 4.03, 2.94, 5.33,
+                  6.575, 6.421, 7.185, 6.998, 7.147,
+                  4.0900, 4.9671, 4.9671, 6.0622, 6.0622,
+                  2.31, 7.07, 7.07, 2.18, 2.18),
+                ncol = 4
+    )
 
-  explanation <- list()
-  explanation$p <- c(31.30145, 23.25194, 33.11547, 33.43015, 31.72984)
-  explanation$dt <- data.table::data.table(
-    "none" = rep(22.00, 5),
-    "lstat" = c(5.2632, 0.1672, 5.9888, 8.2142, 0.5060),
-    "rm" = c(-1.2527, -0.7088, 5.5451, 0.7508, 5.6875),
-    "dis" = c(0.2920, 0.9689, 0.5660, 0.1893, 0.8432),
-    "indus" = c(4.5529, 0.3787, -1.4304, 1.8298, 2.2471)
-  )
-  explanation$x_test <- x
-  attr(explanation, "class") <- c("shapr", "list")
+    colnames(x) <- c("lstat", "rm", "dis", "indus")
+
+    explanation <- list()
+    explanation$p <- c(31.30145, 23.25194, 33.11547, 33.43015, 31.72984)
+    explanation$dt <- data.table::data.table(
+      "none" = rep(22.00, 5),
+      "lstat" = c(5.2632, 0.1672, 5.9888, 8.2142, 0.5060),
+      "rm" = c(-1.2527, -0.7088, 5.5451, 0.7508, 5.6875),
+      "dis" = c(0.2920, 0.9689, 0.5660, 0.1893, 0.8432),
+      "indus" = c(4.5529, 0.3787, -1.4304, 1.8298, 2.2471)
+    )
+    explanation$x_test <- x
+    attr(explanation, "class") <- c("shapr", "list")
 
 
-  # Test -----------
-  p <- plot(explanation, plot_phi0 = FALSE)
+    # Test -----------
+    p <- plot(explanation, plot_phi0 = FALSE)
 
-  expect_equal(colnames(x), unique(as.character(p$data$variable)))
-  expect_equal(explanation$p, unique(p$data$pred))
-  expect_equal(sort(as.vector(as.matrix(explanation$dt[, -c("none")]))), sort(p$data$phi))
+    expect_equal(colnames(x), unique(as.character(p$data$variable)))
+    expect_equal(explanation$p, unique(p$data$pred))
+    expect_equal(sort(as.vector(as.matrix(explanation$dt[, -c("none")]))), sort(p$data$phi))
 
-  p <- plot(explanation, plot_phi0 = TRUE)
+    p <- plot(explanation, plot_phi0 = TRUE)
 
-  expect_equal(colnames(explanation$dt), unique(as.character(p$data$variable)))
-  expect_equal(explanation$p, unique(p$data$pred))
-  expect_equal(sort(as.vector(as.matrix(explanation$dt))), sort(p$data$phi))
+    expect_equal(colnames(explanation$dt), unique(as.character(p$data$variable)))
+    expect_equal(explanation$p, unique(p$data$pred))
+    expect_equal(sort(as.vector(as.matrix(explanation$dt))), sort(p$data$phi))
 
-  p <- plot(explanation, plot_phi0 = TRUE, top_k_features = 2)
+    p <- plot(explanation, plot_phi0 = TRUE, top_k_features = 2)
 
-  expect_equal(2, max(p$data$rank))
+    expect_equal(2, max(p$data$rank))
+  }
 })

--- a/tests/testthat/test-predictions.R
+++ b/tests/testthat/test-predictions.R
@@ -1,50 +1,50 @@
-library(shapr)
-
 context("test-predictions.R")
 
 test_that("Test prediction", {
 
   # Example -----------
-  data("Boston", package = "MASS")
-  dt_train <- data.table::as.data.table(Boston)
-  features <- c("lstat", "rm", "dis", "indus")
-  n_combinations <- 10
-  n_features <- 4
-  prediction_zero <- .5
-  n_xtest <- 8
-  explainer <- list()
-  explainer$model <- stats::lm(formula = "medv ~ lstat + rm + dis + indus", data = head(dt_train, -n_xtest))
-  explainer$x_test <- tail(dt_train[, .SD, .SDcols = features], n_xtest)
-  explainer$W <- matrix(1, nrow = n_features + 1, ncol = n_combinations)
-  dt <- dt_train[, .SD, .SDcols = features][rep(1:.N, 4)]
-  dt[, id := rep_len(1:n_xtest, .N)]
-  dt[, id_combination := rep_len(1:n_combinations, .N), id]
-  dt[, w := runif(.N)]
-  max_id_combination <- dt[, max(id_combination)]
-  dt <- dt[!(id_combination == max_id_combination)]
-  dt_lastrows <- data.table::data.table(
-    explainer$x_test,
-    id = 1:n_xtest,
-    id_combination = max_id_combination,
-    w = 1.0
-  )
-  dt <- rbind(dt, dt_lastrows, dt_lastrows, dt_lastrows)
+  if (requireNamespace("MASS", quietly = TRUE)) {
 
-  x <- prediction(dt, prediction_zero, explainer)
+    data("Boston", package = "MASS")
+    dt_train <- data.table::as.data.table(Boston)
+    features <- c("lstat", "rm", "dis", "indus")
+    n_combinations <- 10
+    n_features <- 4
+    prediction_zero <- .5
+    n_xtest <- 8
+    explainer <- list()
+    explainer$model <- stats::lm(formula = "medv ~ lstat + rm + dis + indus", data = head(dt_train, -n_xtest))
+    explainer$x_test <- tail(dt_train[, .SD, .SDcols = features], n_xtest)
+    explainer$W <- matrix(1, nrow = n_features + 1, ncol = n_combinations)
+    dt <- dt_train[, .SD, .SDcols = features][rep(1:.N, 4)]
+    dt[, id := rep_len(1:n_xtest, .N)]
+    dt[, id_combination := rep_len(1:n_combinations, .N), id]
+    dt[, w := runif(.N)]
+    max_id_combination <- dt[, max(id_combination)]
+    dt <- dt[!(id_combination == max_id_combination)]
+    dt_lastrows <- data.table::data.table(
+      explainer$x_test,
+      id = 1:n_xtest,
+      id_combination = max_id_combination,
+      w = 1.0
+    )
+    dt <- rbind(dt, dt_lastrows, dt_lastrows, dt_lastrows)
 
-  # Test -----------
-  lnms <- c("dt", "model", "p", "x_test")
-  expect_equal(class(x), c("shapr", "list"))
-  expect_equal(names(x), lnms)
-  expect_equal(x$model, explainer$model)
-  expect_equal(x$x_test, explainer$x_test)
-  expect_equal(x$p, predict_model(explainer$model, explainer$x_test))
-  expect_true(data.table::is.data.table(x$dt))
-  expect_equal(ncol(x$dt), n_features + 1)
-  expect_equal(nrow(x$dt), nrow(explainer$x_test))
-  expect_equal(colnames(x$dt), c("none", features))
+    x <- prediction(dt, prediction_zero, explainer)
 
-  # Tets errors
-  expect_error(prediction(dt[id < n_xtest], prediction_zero, explainer))
+    # Test -----------
+    lnms <- c("dt", "model", "p", "x_test")
+    expect_equal(class(x), c("shapr", "list"))
+    expect_equal(names(x), lnms)
+    expect_equal(x$model, explainer$model)
+    expect_equal(x$x_test, explainer$x_test)
+    expect_equal(x$p, predict_model(explainer$model, explainer$x_test))
+    expect_true(data.table::is.data.table(x$dt))
+    expect_equal(ncol(x$dt), n_features + 1)
+    expect_equal(nrow(x$dt), nrow(explainer$x_test))
+    expect_equal(colnames(x$dt), c("none", features))
 
+    # Tets errors
+    expect_error(prediction(dt[id < n_xtest], prediction_zero, explainer))
+  }
 })

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -1,5 +1,3 @@
-library(shapr)
-
 context("test-sample_combinations.R")
 
 test_that("Test sample_combinations", {
@@ -55,89 +53,93 @@ test_that("Test sample_combinations", {
 
 test_that("test sample_gaussian", {
 
-  # Example -----------
-  m <- 10
-  n_samples <- 50
-  mu <- rep(1, m)
-  cov_mat <- cov(matrix(rnorm(n_samples * m), n_samples, m))
-  x_test <- matrix(MASS::mvrnorm(1, mu, cov_mat), nrow = 1)
-  cnms <- paste0("x", seq(m))
-  colnames(x_test) <- cnms
-  index_given <- c(4, 7)
-  r <- sample_gaussian(index_given, n_samples, mu, cov_mat, m, x_test)
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    # Example -----------
+    m <- 10
+    n_samples <- 50
+    mu <- rep(1, m)
+    cov_mat <- cov(matrix(rnorm(n_samples * m), n_samples, m))
+    x_test <- matrix(MASS::mvrnorm(1, mu, cov_mat), nrow = 1)
+    cnms <- paste0("x", seq(m))
+    colnames(x_test) <- cnms
+    index_given <- c(4, 7)
+    r <- sample_gaussian(index_given, n_samples, mu, cov_mat, m, x_test)
 
-  # Test output format ------------------
-  expect_true(data.table::is.data.table(r))
-  expect_equal(ncol(r), m)
-  expect_equal(nrow(r), n_samples)
-  expect_equal(colnames(r), cnms)
+    # Test output format ------------------
+    expect_true(data.table::is.data.table(r))
+    expect_equal(ncol(r), m)
+    expect_equal(nrow(r), n_samples)
+    expect_equal(colnames(r), cnms)
 
-  # Check that the given features are not resampled, but kept as is.
-  for (i in seq(m)) {
-    var_name <- cnms[i]
+    # Check that the given features are not resampled, but kept as is.
+    for (i in seq(m)) {
+      var_name <- cnms[i]
 
-    if (i %in% index_given) {
-      expect_equal(
-        unique(r[[var_name]]), x_test[, var_name][[1]]
-      )
-    } else {
-      expect_true(
-        length(unique(r[[var_name]])) == n_samples
-      )
+      if (i %in% index_given) {
+        expect_equal(
+          unique(r[[var_name]]), x_test[, var_name][[1]]
+        )
+      } else {
+        expect_true(
+          length(unique(r[[var_name]])) == n_samples
+        )
+      }
     }
+
+    # Example 2 -------------
+    # Check that conditioning upon all variables simply returns the test observation.
+    r <- sample_gaussian(1:m, n_samples, mu, cov_mat, m, x_test)
+    expect_identical(r, data.table::as.data.table(x_test))
+
+    # Tests for errors ------------------
+    expect_error(
+      sample_gaussian(m + 1, n_samples, mu, cov_mat, m, x_test)
+    )
+    expect_error(
+      sample_gaussian(m + 1, n_samples, mu, cov_mat, m, as.vector(x_test))
+    )
   }
-
-  # Example 2 -------------
-  # Check that conditioning upon all variables simply returns the test observation.
-  r <- sample_gaussian(1:m, n_samples, mu, cov_mat, m, x_test)
-  expect_identical(r, data.table::as.data.table(x_test))
-
-  # Tests for errors ------------------
-  expect_error(
-    sample_gaussian(m + 1, n_samples, mu, cov_mat, m, x_test)
-  )
-  expect_error(
-    sample_gaussian(m + 1, n_samples, mu, cov_mat, m, as.vector(x_test))
-  )
 })
 
 test_that("test sample_copula", {
-  # Example 1 --------------
-  # Check that the given features are not resampled, but kept as is.
-  m <- 10
-  n <- 40
-  n_samples <- 50
-  mu <- rep(1, m)
-  set.seed(123) # Ensuring consistency in every test
-  cov_mat <- cov(matrix(rnorm(n * m), n, m))
-  x_train <- MASS::mvrnorm(n, mu, cov_mat)
-  x_test <- MASS::mvrnorm(1, mu, cov_mat)
-  x_test_gaussian <- MASS::mvrnorm(1, mu, cov_mat)
-  index_given <- 3:6
-  set.seed(1)
-  ret <- sample_copula(index_given, n_samples, mu, cov_mat, m, x_test_gaussian, x_train, x_test)
-  X_given <- x_test[index_given]
-  res1.1 <- as.data.table(matrix(rep(X_given, each = n_samples), nrow = n_samples))
-  res1.2 <- as.data.table(ret[, ..index_given])
-  colnames(res1.1) <- colnames(res1.2)
+  if (requireNamespace("MASS", quietly = TRUE)) {
+    # Example 1 --------------
+    # Check that the given features are not resampled, but kept as is.
+    m <- 10
+    n <- 40
+    n_samples <- 50
+    mu <- rep(1, m)
+    set.seed(123) # Ensuring consistency in every test
+    cov_mat <- cov(matrix(rnorm(n * m), n, m))
+    x_train <- MASS::mvrnorm(n, mu, cov_mat)
+    x_test <- MASS::mvrnorm(1, mu, cov_mat)
+    x_test_gaussian <- MASS::mvrnorm(1, mu, cov_mat)
+    index_given <- 3:6
+    set.seed(1)
+    ret <- sample_copula(index_given, n_samples, mu, cov_mat, m, x_test_gaussian, x_train, x_test)
+    X_given <- x_test[index_given]
+    res1.1 <- as.data.table(matrix(rep(X_given, each = n_samples), nrow = n_samples))
+    res1.2 <- as.data.table(ret[, ..index_given])
+    colnames(res1.1) <- colnames(res1.2)
 
-  # Example 2 --------------
-  # Check that conditioning upon all variables simply returns the test observation.
-  index_given <- 1:m
-  x2 <- as.data.table(matrix(x_test, ncol = m, nrow = 1))
-  res2 <- sample_copula(index_given, n_samples, mu, cov_mat, m, x_test_gaussian, x_train, x_test)
+    # Example 2 --------------
+    # Check that conditioning upon all variables simply returns the test observation.
+    index_given <- 1:m
+    x2 <- as.data.table(matrix(x_test, ncol = m, nrow = 1))
+    res2 <- sample_copula(index_given, n_samples, mu, cov_mat, m, x_test_gaussian, x_train, x_test)
 
-  # Example 3 --------------
-  # Check that the colnames are preserved.
-  index_given <- c(1, 2, 3, 5, 6)
-  x_test <- t(as.data.frame(x_test))
-  colnames(x_test) <- 1:m
-  res3 <- sample_copula(index_given, n_samples, mu, cov_mat, m, x_test_gaussian, x_train, x_test)
+    # Example 3 --------------
+    # Check that the colnames are preserved.
+    index_given <- c(1, 2, 3, 5, 6)
+    x_test <- t(as.data.frame(x_test))
+    colnames(x_test) <- 1:m
+    res3 <- sample_copula(index_given, n_samples, mu, cov_mat, m, x_test_gaussian, x_train, x_test)
 
-  # Tests ------------------
-  expect_equal(res1.1, res1.2)
-  expect_equal(x2, res2)
-  expect_identical(colnames(res3), colnames(x_test))
-  expect_error(sample_copula(m + 1, n_samples, mu, cov_mat, m, x_test_gaussian, x_train, x_test))
-  expect_true(data.table::is.data.table(res2))
+    # Tests ------------------
+    expect_equal(res1.1, res1.2)
+    expect_equal(x2, res2)
+    expect_identical(colnames(res3), colnames(x_test))
+    expect_error(sample_copula(m + 1, n_samples, mu, cov_mat, m, x_test_gaussian, x_train, x_test))
+    expect_true(data.table::is.data.table(res2))
+  }
 })

--- a/tests/testthat/test-src_impute_data.R
+++ b/tests/testthat/test-src_impute_data.R
@@ -1,5 +1,3 @@
-library(shapr)
-
 context("test-src_impute_data.R")
 
 test_that("Test observation_impute_cpp", {

--- a/tests/testthat/test-src_weighted_matrix.R
+++ b/tests/testthat/test-src_weighted_matrix.R
@@ -1,5 +1,3 @@
-library(shapr)
-
 context("test-src_weighted_matrix.R")
 
 test_that("Test weight_matrix_cpp", {

--- a/tests/testthat/test-transformation.R
+++ b/tests/testthat/test-transformation.R
@@ -1,5 +1,3 @@
-library(shapr)
-
 context("test-transformation.R")
 
 test_that("Test inv_gaussian_transform", {


### PR DESCRIPTION
Xgboost failed on CRAN earlier this month, which caused shapr to fail too as we have it in suggets and uses it in several tests. I got a warning that shapr would be removed from CRAN due to this. The xgboost crew eventually fixed the issue so I though everything was fine. Apparently I had not read the entire email as it stated that packages under Suggests should be used conditionally (if we had done this, it would not have been a problem in the first place) and would not be accepted even if the xgboost issue was fixed. I did not catch this, so today shapr was removed from CRAN.

**This PR tries to get us back by using packages in _tests_ and _examples_ conditionally.** 
CRAN refers to 1.1.3.1 here https://cran.r-project.org/doc/manuals/r-release/R-exts.pdf 
The examples look a bit ugly with the additional requireNamespace-overhead, but at least I can then verify that it runs without Suggested packages using
```
devtools::check(vignettes = FALSE, env_vars=c(`_R_CHECK_DEPENDS_ONLY_` = "true"))
```
There are lots of packages not following this convention for examples and vignettes at least, but I see no other way out at this stage. The vignette is left untouched and still requires Suggested packages. Hopefully that is fine. 

For later, we might want to find a different data set to use (maybe just make one ourself?) to simplify all of this.

NOTE: Checks are failing on macOS for unknown reason, but it runs on macOS through R-hub (R-release): 
`devtools::check_rhub(platforms="macos-highsierra-release-cran")`, so I think it does not matter.