### PR TITLE
Fix UseMethod bug

### DIFF
--- a/R/explanation.R
+++ b/R/explanation.R
@@ -143,16 +143,16 @@ explain <- function(x, explainer, approach, prediction_zero, ...) {
   }
 
 
-
+  this_class <- ""
   if (length(approach) > 1) {
-    class(x) <- "combined"
+    class(this_class) <- "combined"
   } else if (length(extras$mincriterion) > 1) {
-    class(x) <- "ctree_comb_mincrit"
+    class(this_class) <- "ctree_comb_mincrit"
   } else {
-    class(x) <- approach
+    class(this_class) <- approach
   }
 
-  UseMethod("explain", x)
+  UseMethod("explain", this_class)
 }
 
 #' @param type Character. Should be equal to either \code{"independence"},

--- a/R/observations.R
+++ b/R/observations.R
@@ -87,8 +87,9 @@ observation_impute <- function(W_kernel, S, x_train, x_test, w_threshold = .7, n
 #' @export
 #' @keywords internal
 prepare_data <- function(x, ...) {
-  class(x) <- x$approach
-  UseMethod("prepare_data", x)
+  this_class <- ""
+  class(this_class) <- x$approach
+  UseMethod("prepare_data", this_class)
 }
 
 #' @rdname prepare_data

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -30,7 +30,7 @@ test_that("Test functions in explanation.R", {
     explainer <- readRDS(file = "test_objects/shapley_explainer_obj.rds")
     p0 <- mean(y_train)
 
-    # Test way to insert test data (shapr<v0.2.1 threw error for line 2 and 3 below on R>=4.0)
+    # Test way to insert test data (shapr<v0.2.1 threw error for line 2-4 below on R>=4.0)
     expect_silent(explain(x_test, explainer, approach = "gaussian", prediction_zero = p0))
     expect_silent(explain(head(x_test), explainer, approach = "gaussian", prediction_zero = p0))
     expect_silent(explain(x_test[,1:4], explainer, approach = "gaussian", prediction_zero = p0))

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -28,9 +28,16 @@ test_that("Test functions in explanation.R", {
 
     # Prepare the data for explanation. Path needs to be relative to testthat directory in the package
     explainer <- readRDS(file = "test_objects/shapley_explainer_obj.rds")
+    p0 <- mean(y_train)
+
+    # Test way to insert test data (shapr<v0.2.1 threw error for line 2 and 3 below on R>=4.0)
+    expect_silent(explain(x_test, explainer, approach = "gaussian", prediction_zero = p0))
+    expect_silent(explain(head(x_test), explainer, approach = "gaussian", prediction_zero = p0))
+    expect_silent(explain(x_test[,1:4], explainer, approach = "gaussian", prediction_zero = p0))
+    expect_silent(explain(x_test[1:2,], explainer, approach = "gaussian", prediction_zero = p0))
+
 
     # Creating list with lots of different explainer objects
-    p0 <- mean(y_train)
     ex_list <- list()
 
     # Ex 1: Explain predictions (gaussian)


### PR DESCRIPTION
By chance i detected a bug related to our use of UseMethod when overwriting the class of the original object. This appeared in explain and prepare_data. On R>4.0, when the object being inserted into the relevant function does not exists itself in the calling environment, the class assigned to that object still has the new class when entering the relevant class function in UseMethod. This causes error. I don't know of any other way to call specific class for a function (except writing the name out explicitly), but using a temporary class object seems to do the trick. The last line of the code below fails on current master (on R4.0 and above), but passes in this PR.

```
data("Boston", package = "MASS")

x_var <- c("lstat", "rm", "dis", "indus")
y_var <- "medv"
x_train <- Boston[, x_var]
model <- lm(medv ~ lstat + rm + dis + indus, data = Boston)
explainer <- shapr(x_train, model)

x_test <- head(x_train)

ok <- explain(x_test,explainer,approach="empirical",prediction_zero=0.5)
not_ok <- explain(head(x_train),explainer,approach="empirical",prediction_zero=0.5)
```