### PR TITLE
Allow passing of covariance matrix from explain to empirical

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: shapr
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Title: Prediction Explanation with Dependence-Aware Shapley Values
 Description: Complex machine learning models are often hard to interpret. However, in 
   many situations it is crucial to understand and explain why a model made a specific 
@@ -24,7 +24,7 @@ Encoding: UTF-8
 LazyData: true
 ByteCompile: true
 Language: en-US
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Depends: R (>= 3.5.0)
 Imports: 
     stats,

--- a/R/observations.R
+++ b/R/observations.R
@@ -155,7 +155,8 @@ prepare_data.empirical <- function(x, seed = 1, index_features = NULL, ...) {
   x$D <- distance_matrix(
     x$x_train,
     x$x_test,
-    x$X$features[index_features]
+    x$X$features[index_features],
+    mcov = x$cov_mat
   )
 
   # Setup

--- a/R/shapley.R
+++ b/R/shapley.R
@@ -238,13 +238,11 @@ shapr <- function(x,
 }
 
 #' @keywords internal
-distance_matrix <- function(x_train, x_test = NULL, list_features) {
+distance_matrix <- function(x_train, x_test = NULL, list_features, mcov) {
   if (is.null(x_test)) {
     return(NULL)
   }
 
-  # Get covariance matrix
-  mcov <- stats::cov(x_train)
   if (is.null(dim(x_test))) {
     x_test <- t(as.matrix(x_test))
   }

--- a/man/explain.Rd
+++ b/man/explain.Rd
@@ -27,6 +27,7 @@ explain(x, explainer, approach, prediction_zero, n_samples = 1000, ...)
   n_samples_aicc = 1000,
   eval_max_aicc = 20,
   start_aicc = 0.1,
+  cov_mat = NULL,
   ...
 )
 
@@ -113,13 +114,13 @@ optimizing the AICc. Note that this argument is only applicable when
 is only applicable when \code{approach = "empirical"}, and \code{type} is either equal to
 \code{"AICc_each_k"} or \code{"AICc_full"}}
 
-\item{mu}{Numeric vector. (Optional) Containing the mean of the data generating distribution.
-If \code{NULL} the expected values are estimated from the data. Note that this is only used
-when \code{approach = "gaussian"}.}
-
 \item{cov_mat}{Numeric matrix. (Optional) Containing the covariance matrix of the data
 generating distribution. \code{NULL} means it is estimated from the data if needed
 (in the Gaussian approach).}
+
+\item{mu}{Numeric vector. (Optional) Containing the mean of the data generating distribution.
+If \code{NULL} the expected values are estimated from the data. Note that this is only used
+when \code{approach = "gaussian"}.}
 
 \item{mincriterion}{Numeric value or vector where length of vector is the number of features in model.
 Value is equal to 1 - alpha where alpha is the nominal level of the conditional

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -337,15 +337,19 @@ test_that("Test functions in explanation.R", {
 
     # Check that the same results are obtained if you pass the covariance matrix or whether it is computed internally
     # Gaussian approach
-    explained_gaus_cov <- explain(x_test, explainer, approach = "gaussian", prediction_zero = p0, cov_mat = cov(explainer$x_train))
-    explained_gaus_no_cov <- explain(x_test, explainer, approach = "gaussian", prediction_zero = p0)
+    explained_gaus_cov <- explain(x_test, explainer, approach = "gaussian",
+                                  prediction_zero = p0, cov_mat = cov(explainer$x_train))
+    explained_gaus_no_cov <- explain(x_test, explainer, approach = "gaussian",
+                                     prediction_zero = p0)
 
     # Empirical approach
-    explained_emp_cov <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, cov_mat = cov(explainer$x_train))
-    explained_emp_no_cov <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0)
+    explained_emp_cov <- explain(x_test, explainer, approach = "empirical",
+                                 prediction_zero = p0, cov_mat = cov(explainer$x_train))
+    explained_emp_no_cov <- explain(x_test, explainer, approach = "empirical",
+                                    prediction_zero = p0)
 
-    expect_equal(explained_gaus_cov,explained_gaus_no_cov)
-    expect_equal(explained_emp_cov,explained_emp_no_cov)
+    expect_equal(explained_gaus_cov, explained_gaus_no_cov)
+    expect_equal(explained_emp_cov, explained_emp_no_cov)
 
   }
 })

--- a/tests/testthat/test-explanation.R
+++ b/tests/testthat/test-explanation.R
@@ -334,6 +334,19 @@ test_that("Test functions in explanation.R", {
     expect_error(
       explain(x_test, explainer, approach = rep("gaussian", ncol(x_test) + 1), prediction_zero = p0)
     )
+
+    # Check that the same results are obtained if you pass the covariance matrix or whether it is computed internally
+    # Gaussian approach
+    explained_gaus_cov <- explain(x_test, explainer, approach = "gaussian", prediction_zero = p0, cov_mat = cov(explainer$x_train))
+    explained_gaus_no_cov <- explain(x_test, explainer, approach = "gaussian", prediction_zero = p0)
+
+    # Empirical approach
+    explained_emp_cov <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0, cov_mat = cov(explainer$x_train))
+    explained_emp_no_cov <- explain(x_test, explainer, approach = "empirical", prediction_zero = p0)
+
+    expect_equal(explained_gaus_cov,explained_gaus_no_cov)
+    expect_equal(explained_emp_cov,explained_emp_no_cov)
+
   }
 })
 


### PR DESCRIPTION
For the Gaussian method it is possible to pass the covariance matrix (and mean) of the features from explain(). This PR allows the same for the empirical method (which uses it in the computation of the Mahlanobis distance). 

If not provided the covariance matrix is estimated by the empirical covariance matrix of the (training) data (from the explainer-object). This is now done in the explain object as for the Gaussian method instead of within the distance function in prepare_data.

- Documentation updated
- Tests for equality when passing the covariance matrix and computing it internally are added
- The version number is dumped