### PR TITLE
Add support for models with prediction output size above 1.

### DIFF
--- a/R/compute_vS.R
+++ b/R/compute_vS.R
@@ -4,14 +4,14 @@
 #' @inheritParams default_doc
 #' @inheritParams explain
 #'
-#' @param method Character
+#' @param parallel Logical.
 #' Indicates whether the lappy method (default) or loop method should be used.
 #'
 #' @export
-compute_vS <- function(internal, model, predict_model, method = "future") {
+compute_vS <- function(internal, model, predict_model, parallel = TRUE) {
   S_batch <- internal$objects$S_batch
 
-  if (method == "future") {
+  if (parallel) {
     ret <- future_compute_vS_batch(
       S_batch = S_batch,
       internal = internal,

--- a/R/explain.R
+++ b/R/explain.R
@@ -81,6 +81,10 @@
 #' disabled for unsupported model classes.
 #' Can also be used to override the default function for natively supported model classes.
 #'
+#' @param output_size Integer.
+#' Indicates the size of the output for the model, to explain models with multiple outputs
+#' such as forecasts multiple steps ahead. The size of prediction_zero must match output_size.
+#'
 #' @param parallel Logical.
 #' Indicates whether the algorithm should be run in parallel (default) or sequentially.
 #'
@@ -255,6 +259,7 @@ explain <- function(model,
                     keep_samp_for_vS = FALSE,
                     predict_model = NULL,
                     get_model_specs = NULL,
+                    output_size = 1,
                     parallel = TRUE,
                     ...) { # ... is further arguments passed to specific approaches
 
@@ -272,6 +277,7 @@ explain <- function(model,
     x_explain = x_explain,
     approach = approach,
     prediction_zero = prediction_zero,
+    output_size = output_size,
     n_combinations = n_combinations,
     group = group,
     n_samples = n_samples,
@@ -286,7 +292,8 @@ explain <- function(model,
   predict_model <- get_predict_model(
     x_test = head(internal$data$x_train, 2),
     predict_model = predict_model,
-    model = model
+    model = model,
+    output_size = output_size
   )
 
   # Sets up the Shapley (sampling) framework and prepares the
@@ -298,7 +305,7 @@ explain <- function(model,
   # Get the samples for the conditional distributions with the specified approach
   # Predict with these samples
   # Perform MC integration on these to estimate the conditional expectation (v(S))
-  vS_list <- compute_vS(internal, model, predict_model, parallel)
+  vS_list <- compute_vS(internal, model, predict_model, output_size, parallel)
 
   # Compute Shapley values based on conditional expectations (v(S))
   # Organize function output

--- a/R/explain.R
+++ b/R/explain.R
@@ -81,6 +81,9 @@
 #' disabled for unsupported model classes.
 #' Can also be used to override the default function for natively supported model classes.
 #'
+#' @param parallel Logical.
+#' Indicates whether the algorithm should be run in parallel (default) or sequentially.
+#'
 #' @inheritDotParams setup_approach.empirical
 #' @inheritDotParams setup_approach.independence
 #' @inheritDotParams setup_approach.gaussian
@@ -252,6 +255,7 @@ explain <- function(model,
                     keep_samp_for_vS = FALSE,
                     predict_model = NULL,
                     get_model_specs = NULL,
+                    parallel = TRUE,
                     ...) { # ... is further arguments passed to specific approaches
 
   set.seed(seed)
@@ -294,7 +298,7 @@ explain <- function(model,
   # Get the samples for the conditional distributions with the specified approach
   # Predict with these samples
   # Perform MC integration on these to estimate the conditional expectation (v(S))
-  vS_list <- compute_vS(internal, model, predict_model)
+  vS_list <- compute_vS(internal, model, predict_model, parallel)
 
   # Compute Shapley values based on conditional expectations (v(S))
   # Organize function output

--- a/R/explain.R
+++ b/R/explain.R
@@ -26,6 +26,7 @@
 #' features.
 #' Typically we set this value equal to the mean of the response variable in our training data, but other choices
 #' such as the mean of the predictions in the training data are also reasonable.
+#' This can be set to a numeric vector, where the length denotes the output size of the predict function.
 #'
 #' @param n_combinations Integer.
 #' If `group = NULL`, `n_combinations` represents the number of unique feature combinations to sample.
@@ -64,6 +65,8 @@
 #' models.)
 #' The function must have two arguments, `model` and `newdata` which specify, respectively, the model
 #' and a data.frame/data.table to compute predictions for. The function must give the prediction as a numeric vector.
+#' In the case where prediction_zero has length over 1, the output should be a data.frame where the rows correspond
+#' to different rows of x_explain and the columns correspond to the multiple outputs of each prediction.
 #' `NULL` (the default) uses functions specified internally.
 #' Can also be used to override the default function for natively supported model classes.
 #'
@@ -80,13 +83,6 @@
 #' If `NULL` (the default) internal functions are used for natively supported model classes, and the checking is
 #' disabled for unsupported model classes.
 #' Can also be used to override the default function for natively supported model classes.
-#'
-#' @param output_size Integer.
-#' Indicates the size of the output for the model, to explain models with multiple outputs
-#' such as forecasts multiple steps ahead. The size of prediction_zero must match output_size.
-#'
-#' @param parallel Logical.
-#' Indicates whether the algorithm should be run in parallel (default) or sequentially.
 #'
 #' @inheritDotParams setup_approach.empirical
 #' @inheritDotParams setup_approach.independence
@@ -259,11 +255,15 @@ explain <- function(model,
                     keep_samp_for_vS = FALSE,
                     predict_model = NULL,
                     get_model_specs = NULL,
-                    output_size = 1,
-                    parallel = TRUE,
                     ...) { # ... is further arguments passed to specific approaches
 
   set.seed(seed)
+
+  # This can be set to false for easier debugging.
+  parallel <- FALSE
+
+  # Output size of the predict_model function should be the length of prediction_zero.
+  output_size <- length(prediction_zero)
 
   # Gets and check feature specs from the model
   feature_specs <- get_feature_specs(get_model_specs, model)

--- a/R/finalize_explanation.R
+++ b/R/finalize_explanation.R
@@ -46,7 +46,7 @@ postprocess_vS_list <- function(vS_list, internal) {
 
   # Appending the zero-prediction to the list
   dt_vS0 <- as.data.table(rbind(c(1, rep(prediction_zero, n_explain))))
-  names(dt_vS0) <- c("id_combination", seq_len(n_explain))
+  names(dt_vS0) <- names(vS_list[[1]])
 
   # Extracting/merging the data tables from the batch running
   # TODO: Need a memory and speed optimized way to transform the output form dt_vS_list to two different lists,
@@ -104,7 +104,7 @@ compute_shapley_new <- function(internal, dt_vS) {
     shap_names <- names(internal$parameters$group) # TODO: Add group_names (and feature_names) to internal earlier
   }
 
-  kshap <- t(W %*% as.matrix(dt_vS[, -"id_combination"]))
+  kshap <- t(W %*% matrix(unlist(dt_vS[, -"id_combination"]), nrow=nrow(dt_vS)))
   dt_kshap <- data.table::as.data.table(kshap)
   colnames(dt_kshap) <- c("none", shap_names)
 

--- a/R/get_predict_model.R
+++ b/R/get_predict_model.R
@@ -3,7 +3,7 @@
 #'
 #' @inheritParams default_doc
 #' @keywords internal
-get_predict_model <- function(x_test, predict_model, model) {
+get_predict_model <- function(x_test, predict_model, model, output_size) {
 
   # Checks that predict_model is a proper function (R + py)
   # Extracts natively supported functions for predict_model if exists and not passed (R only)
@@ -45,8 +45,8 @@ get_predict_model <- function(x_test, predict_model, model) {
                 "A basic function test threw the following error:\n",as.character(tmp[[1]])))
   }
 
-  if (!(all(is.numeric(tmp)) &&
-        length(tmp) == 2)) {
+  if (!((all(is.numeric(tmp)) || all(sapply(tmp, is.numeric))) &&
+        nrow(tmp) == 2 && ncol(tmp) == output_size)) {
     stop(
       paste0(
         "The predict_model function of class `", class(model),

--- a/R/get_predict_model.R
+++ b/R/get_predict_model.R
@@ -46,7 +46,7 @@ get_predict_model <- function(x_test, predict_model, model, output_size) {
   }
 
   if (!((all(is.numeric(tmp)) || all(sapply(tmp, is.numeric))) &&
-        nrow(tmp) == 2 && ncol(tmp) == output_size)) {
+        (length(tmp) == 2 || (nrow(tmp) == 2 && ncol(tmp) == output_size)))) {
     stop(
       paste0(
         "The predict_model function of class `", class(model),

--- a/R/get_predict_model.R
+++ b/R/get_predict_model.R
@@ -50,7 +50,9 @@ get_predict_model <- function(x_test, predict_model, model, output_size) {
     stop(
       paste0(
         "The predict_model function of class `", class(model),
-        "` does not return a numeric output of the desired length.\n",
+        "` does not return a numeric output of the desired length\n",
+        "for single output models or a data.table of the correct\n",
+        "dimensions for a multiple output model.\n",
         "See the 'Advanced usage' section of the vignette:\n",
         "vignette('understanding_shapr', package = 'shapr')\n\n",
         "for more information on running shapr with custom models.\n"

--- a/R/setup.R
+++ b/R/setup.R
@@ -19,6 +19,7 @@ setup <- function(x_train,
                   x_explain,
                   approach,
                   prediction_zero,
+                  output_size,
                   n_combinations,
                   group,
                   n_samples,
@@ -32,6 +33,7 @@ setup <- function(x_train,
   internal$parameters <- get_parameters(
     approach = approach,
     prediction_zero = prediction_zero,
+    output_size = output_size,
     n_combinations = n_combinations,
     group = group,
     n_samples = n_samples,
@@ -273,7 +275,7 @@ get_extra_parameters <- function(internal){
 }
 
 #' @keywords internal
-get_parameters <- function(approach, prediction_zero, n_combinations, group, n_samples,
+get_parameters <- function(approach, prediction_zero, output_size, n_combinations, group, n_samples,
                            n_batches, seed, keep_samp_for_vS, is_python, ...) {
 
   # Check input type for approach
@@ -281,9 +283,9 @@ get_parameters <- function(approach, prediction_zero, n_combinations, group, n_s
   # approach is checked later
 
   # prediction_zero
-  if(!(is.numeric(prediction_zero) &&
-       length(prediction_zero)==1 &&
-       !is.na(prediction_zero))){
+  if(!(all(is.numeric(prediction_zero)) &&
+       length(prediction_zero)==output_size &&
+       all(!is.na(prediction_zero)))){
     stop("`prediction_zero` must be a single numeric.")
   }
   # n_combinations


### PR DESCRIPTION
This adds support for models that have predict functions with size over 1. For example a time-series forecast model which forecasts 3 steps ahead. In general, any model which has multiple outputs in its predict function should now be supported.

After discussion with Martin I have made it so that there are no new arguments to the explain function, rather the input "prediction_zero" must be of the same size as the outputs from the predict function of the model.