### PR TITLE
Fixed a bug with the `gaussian` approach not using the user-provided …

### DIFF
--- a/R/approach_gaussian.R
+++ b/R/approach_gaussian.R
@@ -14,11 +14,10 @@
 setup_approach.gaussian <- function(internal,
                                     gaussian.mu = NULL,
                                     gaussian.cov_mat = NULL, ...) {
+
   parameters <- internal$parameters
   x_train <- internal$data$x_train
   feature_specs <- internal$objects$feature_specs
-
-  # TO DO: gaussian.mu should probably be extracted from internal$parameters$gaussian.mu...
 
   # Checking if factor features are present
   if (any(feature_specs$classes == "factor")) {
@@ -31,20 +30,17 @@ setup_approach.gaussian <- function(internal,
     ))
   }
 
-  # If gaussian.mu is not provided directly, use mean of training data
-  if (is.null(gaussian.mu)) {
+  # If gaussian.mu is not provided directly in internal list, use mean of training data
+  if (is.null(parameters$gaussian.mu)) {
     parameters$gaussian.mu <- get_mu_vec(x_train)
-  } else {
-    parameters$gaussian.mu <- gaussian.mu
   }
 
-  # If gaussian.cov_mat is not provided directly, use sample covariance of training data
-  if (is.null(gaussian.cov_mat)) {
+  # If gaussian.cov_mat is not provided directly in internal list, use sample covariance of training data
+  if (is.null(parameters$gaussian.cov_mat)) {
     parameters$gaussian.cov_mat <- get_cov_mat(x_train)
-  } else {
-    parameters$gaussian.cov_mat <- gaussian.cov_mat
   }
 
+  # Add the (potentially) updated Gaussian parameters
   internal$parameters <- parameters
 
   return(internal)

--- a/R/approach_gaussian.R
+++ b/R/approach_gaussian.R
@@ -15,7 +15,10 @@ setup_approach.gaussian <- function(internal,
                                     gaussian.mu = NULL,
                                     gaussian.cov_mat = NULL, ...) {
 
-  parameters <- internal$parameters
+  # For consistency
+  defaults <- mget(c("gaussian.mu", "gaussian.cov_mat"))
+  internal <- insert_defaults(internal, defaults)
+
   x_train <- internal$data$x_train
   feature_specs <- internal$objects$feature_specs
 
@@ -31,17 +34,14 @@ setup_approach.gaussian <- function(internal,
   }
 
   # If gaussian.mu is not provided directly in internal list, use mean of training data
-  if (is.null(parameters$gaussian.mu)) {
-    parameters$gaussian.mu <- get_mu_vec(x_train)
+  if (is.null(internal$parameters$gaussian.mu)) {
+    internal$parameters$gaussian.mu <- get_mu_vec(x_train)
   }
 
   # If gaussian.cov_mat is not provided directly in internal list, use sample covariance of training data
-  if (is.null(parameters$gaussian.cov_mat)) {
-    parameters$gaussian.cov_mat <- get_cov_mat(x_train)
+  if (is.null(internal$parameters$gaussian.cov_mat)) {
+    internal$parameters$gaussian.cov_mat <- get_cov_mat(x_train)
   }
-
-  # Add the (potentially) updated Gaussian parameters
-  internal$parameters <- parameters
 
   return(internal)
 }

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -509,11 +509,10 @@ test_that("output_lm_numeric_independence_keep_samp_for_vS", {
       prediction_zero = p0,
       n_batches = 1,
       timing = FALSE,
-      keep_samp_for_vS = T
+      keep_samp_for_vS = TRUE
     )),
     "output_lm_numeric_independence_keep_samp_for_vS"
   )
 
   expect_false(is.null(out$internal$output$dt_samp_for_vS))
 })
-

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1544,3 +1544,55 @@ test_that("different n_batches gives same/different shapley values for different
     explain.ctree_n_batches_10$shapley_values
   ))
 })
+
+test_that("gaussian approach use the user provided parameters", {
+  # approach "gaussian" with default parameter estimation, i.e., sample mean and covariance
+  explain.gaussian_sample_mean_and_covariance <- explain(
+    model = model_lm_numeric,
+    x_explain = x_explain_numeric,
+    x_train = x_train_numeric,
+    approach = "gaussian",
+    prediction_zero = p0,
+    timing = FALSE
+  )
+
+  # Expect that gaussian.mu is the sample mean when no values are provided
+  expect_identical(
+    explain.gaussian_sample_mean_and_covariance$internal$parameters$gaussian.mu,
+    colMeans(unname(x_train_numeric))
+  )
+
+  # Expect that gaussian.mu is the sample covariance when no values are provided
+  expect_identical(
+    explain.gaussian_sample_mean_and_covariance$internal$parameters$gaussian.cov_mat,
+    cov(x_train_numeric)
+  )
+
+  # Provide parameter values for the Gaussian approach
+  gaussian.provided_mu = seq(ncol(x_train_numeric)) # 1,2,3,4,5
+  gaussian.provided_cov_mat = diag(ncol(x_train_numeric))
+
+  # approach "gaussian" with provided parameters
+  explain.gaussian_provided_mean_and_covariance <- explain(
+    model = model_lm_numeric,
+    x_explain = x_explain_numeric,
+    x_train = x_train_numeric,
+    approach = "gaussian",
+    prediction_zero = p0,
+    timing = FALSE,
+    gaussian.mu = gaussian.provided_mu,
+    gaussian.cov_mat = gaussian.provided_cov_mat
+  )
+
+  # Expect that the gaussian.mu parameter is the same as the provided gaussian.provided_mu
+  expect_identical(
+    explain.gaussian_provided_mean_and_covariance$internal$parameters$gaussian.mu,
+    gaussian.provided_mu
+  )
+
+  # Expect that gaussian.cov_mat is the same as the provided gaussian.provided_cov_mat
+  expect_identical(
+    explain.gaussian_provided_mean_and_covariance$internal$parameters$gaussian.cov_mat,
+    gaussian.provided_cov_mat
+  )
+})

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1547,7 +1547,7 @@ test_that("different n_batches gives same/different shapley values for different
 
 test_that("gaussian approach use the user provided parameters", {
   # approach "gaussian" with default parameter estimation, i.e., sample mean and covariance
-  explain.gaussian_sample_mean_and_covariance <- explain(
+  e.gaussian_samp_mean_cov <- explain(
     model = model_lm_numeric,
     x_explain = x_explain_numeric,
     x_train = x_train_numeric,
@@ -1558,22 +1558,22 @@ test_that("gaussian approach use the user provided parameters", {
 
   # Expect that gaussian.mu is the sample mean when no values are provided
   expect_equal(
-    explain.gaussian_sample_mean_and_covariance$internal$parameters$gaussian.mu,
+    e.gaussian_samp_mean_cov$internal$parameters$gaussian.mu,
     colMeans(unname(x_train_numeric))
   )
 
   # Expect that gaussian.cov_mat is the sample covariance when no values are provided
   expect_equal(
-    explain.gaussian_sample_mean_and_covariance$internal$parameters$gaussian.cov_mat,
+    e.gaussian_samp_mean_cov$internal$parameters$gaussian.cov_mat,
     cov(x_train_numeric)
   )
 
   # Provide parameter values for the Gaussian approach
-  gaussian.provided_mu = seq(ncol(x_train_numeric)) # 1,2,3,4,5
-  gaussian.provided_cov_mat = diag(ncol(x_train_numeric))
+  gaussian.provided_mu <- seq_len(ncol(x_train_numeric)) # 1,2,3,4,5
+  gaussian.provided_cov_mat <- diag(ncol(x_train_numeric))
 
   # approach "gaussian" with provided parameters
-  explain.gaussian_provided_mean_and_covariance <- explain(
+  e.gaussian_provided_mean_cov <- explain(
     model = model_lm_numeric,
     x_explain = x_explain_numeric,
     x_train = x_train_numeric,
@@ -1586,13 +1586,13 @@ test_that("gaussian approach use the user provided parameters", {
 
   # Expect that the gaussian.mu parameter is the same as the provided gaussian.provided_mu
   expect_equal(
-    explain.gaussian_provided_mean_and_covariance$internal$parameters$gaussian.mu,
+    e.gaussian_provided_mean_cov$internal$parameters$gaussian.mu,
     gaussian.provided_mu
   )
 
   # Expect that gaussian.cov_mat is the same as the provided gaussian.provided_cov_mat
   expect_equal(
-    explain.gaussian_provided_mean_and_covariance$internal$parameters$gaussian.cov_mat,
+    e.gaussian_provided_mean_cov$internal$parameters$gaussian.cov_mat,
     gaussian.provided_cov_mat
   )
 })

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1557,13 +1557,13 @@ test_that("gaussian approach use the user provided parameters", {
   )
 
   # Expect that gaussian.mu is the sample mean when no values are provided
-  expect_identical(
+  expect_equal(
     explain.gaussian_sample_mean_and_covariance$internal$parameters$gaussian.mu,
     colMeans(unname(x_train_numeric))
   )
 
-  # Expect that gaussian.mu is the sample covariance when no values are provided
-  expect_identical(
+  # Expect that gaussian.cov_mat is the sample covariance when no values are provided
+  expect_equal(
     explain.gaussian_sample_mean_and_covariance$internal$parameters$gaussian.cov_mat,
     cov(x_train_numeric)
   )
@@ -1585,13 +1585,13 @@ test_that("gaussian approach use the user provided parameters", {
   )
 
   # Expect that the gaussian.mu parameter is the same as the provided gaussian.provided_mu
-  expect_identical(
+  expect_equal(
     explain.gaussian_provided_mean_and_covariance$internal$parameters$gaussian.mu,
     gaussian.provided_mu
   )
 
   # Expect that gaussian.cov_mat is the same as the provided gaussian.provided_cov_mat
-  expect_identical(
+  expect_equal(
     explain.gaussian_provided_mean_and_covariance$internal$parameters$gaussian.cov_mat,
     gaussian.provided_cov_mat
   )


### PR DESCRIPTION
…values for the `gaussian.mu` and `gaussian.cov_mat` arguments, and added a test function. Discuss with Martin what to do with the 2nd and 3rd function arguments, as they are unnecessary, and the roxygen2 documentation.

Previously, the `setup_approach.gaussian` function did not extract the `gaussian.mu` and `gaussian.cov_mat` arguments from the `internal` list but rather let them be two separate arguments in the function call. 
However, they never reached the function as they were part of the `...` arguments, which were not a part of the `setup_computation(internal, model, predict_model)` call in the `explain` function, which calls the `setup_approach.gaussian` function.