### PR TITLE
Lars/add MSEv eval criterion

### DIFF
--- a/vignettes/understanding_shapr.Rmd
+++ b/vignettes/understanding_shapr.Rmd
@@ -560,6 +560,192 @@ explanation_timeseries <- explain(
 )
 ```
 
+
+## MSEv evaluation criterion
+
+NOTE: Discuss with Martin if this function should part of the general `plot.shapr` function and
+that we should get plots of the MSEv evaluation criterion by setting `plot_type = "MSEv"`.
+I like that idea for the sake of consistency, however, then the `plot.shapr` function has to be
+rewritten a bit as I allow for list of explanations objects and do not need to do all the stuff
+as that function does related to Shapley values, since I am only doing contribution function stuff.
+Also. It does not seem that the vignette manages to include mathcal. Can also see that in the 
+vignette which is online on cran at the moment: "https://cran.r-project.org/web/packages/shapr/vignettes/understanding_shapr.html".
+
+We can use the $\operatorname{MSE}_{v}$ criterion proposed by @frye2020shapley,
+and later used by, e.g., @olsen2022using and @olsen2023comparative, to evaluate
+and rank the approaches/methods. The $\operatorname{MSE}_{v}$ is given by
+
+```{=tex}
+\begin{align}
+    \label{eq:MSE_v}
+    \operatorname{MSE}_{v} = \operatorname{MSE}_{v}(\text{method } \texttt{q}) 
+    =
+     \frac{1}{N_\mathcal{S}} \sum_{\mathcal{S} \in \mathcal{P}(\mathcal{M})} \frac{1}{N_\text{test}}
+     \sum_{i=1}^{N_\text{test}} \left( f(\boldsymbol{x}^{[i]}) - {\hat{v}}_{\texttt{q}}(\mathcal{S}, \boldsymbol{x}^{[i]})\right)^2\!,
+\end{align}
+```
+where $N_\mathcal{S} = |\mathcal{P}(\mathcal{M})| = 2^M$ and ${\hat{v}}_{\texttt{q}}$ is the
+estimated contribution function using method $\texttt{q}$. The motivation behind the
+$\operatorname{MSE}_{v}$ criterion is that 
+$\mathbb{E}_\mathcal{S}\mathbb{E}_{\boldsymbol{x}} (v_{\texttt{true}}(\mathcal{S},\boldsymbol{x}) - \hat{v}_{\texttt{q}}(\mathcal{S}, \boldsymbol{x}))^2$
+can be decomposed as
+```{=tex}
+\begin{align}
+    \label{eq:expectation_decomposition}
+    \begin{split}
+    \mathbb{E}_\mathcal{S}\mathbb{E}_{\boldsymbol{x}} (v_{\texttt{true}}(\mathcal{S}, \boldsymbol{x})- \hat{v}_{\texttt{q}}(\mathcal{S}, \boldsymbol{x}))^2 
+    &=
+    \mathbb{E}_\mathcal{S}\mathbb{E}_{\boldsymbol{x}} (f(\boldsymbol{x}) - \hat{v}_{\texttt{q}}(\mathcal{S}, \boldsymbol{x}))^2 \\
+    &\phantom{\,\,\,\,\,\,\,}- \mathbb{E}_\mathcal{S}\mathbb{E}_{\boldsymbol{x}} (f(\boldsymbol{x})-v_{\texttt{true}}(\mathcal{S}, \boldsymbol{x}))^2,
+    \end{split}
+\end{align}
+```
+see Appendix A in @covert2020understanding. The first term on the right-hand side of 
+the equation above can be estimated by $\operatorname{MSE}_{v}$, while the second
+term is a fixed (unknown) constant not influenced by the approach \texttt{q}. Thus, a low value
+of $\operatorname{MSE}_{v}$ indicates that the estimated contribution function $\hat{v}_{\texttt{q}}$
+is closer to the true counterpart $v_{\texttt{true}}$ than a high value.
+
+
+### Advantage:
+An advantage of the $\operatorname{MSE}_{v}$ criterion is that $v_\texttt{true}$ is not involved.
+Thus, we can apply it as an evaluation criterion to real-world data sets where the true
+Shapley values are unknown.
+
+### Disadvantages:
+First, we can only use the $\operatorname{MSE}_{v}$ criterion to rank the methods and not assess
+their closeness to the optimum since the minimum value of the $\operatorname{MSE}_{v}$ criterion
+is unknown. Second, the criterion evaluates the contribution functions and not the Shapley values.
+
+Note that @olsen2023comparative observed a relatively linear relationship between the 
+$\operatorname{MSE}_{v}$ criterion and the mean absolute error $(\operatorname{MAE})$ between the 
+true and estimated Shapley values in extensive simulation studies where the true Shapley values
+were known. That is, a method that achieves a low  $\operatorname{MSE}_{v}$ score also tends to
+obtain a low $\operatorname{MAE}$ score, and vice versa.
+
+
+### MSEv examples
+
+Start by explaining the predictions by using different methods and combining them into lists.
+```{r}
+# Independence approach
+explanation_independence = explain(
+  model = model,
+  x_explain = x_explain,
+  x_train = x_train,
+  approach = "independence",
+  prediction_zero = p0,
+  n_samples = 1e2
+)
+
+# Empirical approach
+explanation_empirical = explain(
+  model = model,
+  x_explain = x_explain,
+  x_train = x_train,
+  approach = "empirical",
+  prediction_zero = p0,
+  n_samples = 1e2
+)
+
+# Gaussian 1e1 approach
+explanation_gaussian_1e1 = explain(
+  model = model,
+  x_explain = x_explain,
+  x_train = x_train,
+  approach = "gaussian",
+  prediction_zero = p0,
+  n_samples = 1e1
+)
+
+# Gaussian 1e2 approach
+explanation_gaussian_1e2 = explain(
+  model = model,
+  x_explain = x_explain,
+  x_train = x_train,
+  approach = "gaussian",
+  prediction_zero = p0,
+  n_samples = 1e2
+)
+
+# Combined approach
+explanation_combined = explain(
+  model = model,
+  x_explain = x_explain,
+  x_train = x_train,
+  approach = c("gaussian", "ctree", "empirical", "empirical"),
+  prediction_zero = p0,
+  n_samples = 1e2
+)
+
+# Create a list of explanations without names
+explanation_list_unnamed = list(
+  explanation_independence,
+  explanation_empirical,
+  explanation_gaussian_1e1,
+  explanation_gaussian_1e2,
+  explanation_combined 
+)
+
+# Create a list of explanations with names
+explanation_list_named = list(
+  "Ind." = explanation_independence,
+  "Emp." = explanation_empirical,
+  "Gaus. 1e1" = explanation_gaussian_1e1,
+  "Gaus. 1e2" = explanation_gaussian_1e2,
+  "Combined" = explanation_combined 
+)
+```
+
+
+We can then compare the different approaches by creating plots of the $\operatorname{MSE}_{v}$ evaluation criterion.
+
+```{r}
+# The function will set default names
+plots_unnamed = make_MSEv_evaluation_criterion_plots(explanation_list_unnamed)
+
+# The function use the provided names
+plots_named = make_MSEv_evaluation_criterion_plots(explanation_list_named)
+
+# See the types of plots produced
+names(plots_named)
+```
+
+We can also change many parameters to alter the plots, both design-wise but also
+to only plot certain coalitions and/or explicands. We can also look at the the
+$\operatorname{MSE}_{v}$ evaluation criterion for each coalition and explicand,
+where we have only averaged over the explicands and coalitions, respectively.
+
+```{r}
+plots_named_v2 = make_MSEv_evaluation_criterion_plots(
+  explanation_list_named,
+  index_combinations = c(1:3, 10, 15),
+  index_explicands = c(1, 3:4, 6),
+  ggplot_theme = ggplot2::theme_minimal(),
+  brewer_palette = NULL,
+  brewer_direction = -1,
+  title_text_size = 14,
+  bar_text_color = "black",
+  bar_text_size = 3,
+  bar_text_n_decimals = 0,
+  point_size = 5,
+  point_shape = "square",
+  line_type = "dashed",
+  line_width = 1,
+  add_error_bars = FALSE,
+  rotate_feature_names_45_degrees = TRUE,
+  flip_coordinates = TRUE
+)
+
+# Look at some of the individual plots
+plots_named_v2$bar_plot_MSEv_for_each_coalition
+plots_named_v2$line_point_plot_MSEv_for_each_explicand
+
+# Plot created without altering the plotting parameters
+plots_named$line_point_plot_MSEv_for_each_explicand
+```
+
+
 ## Main arguments in `explain`
 
 When using `explain`, the default behavior is to use all feature


### PR DESCRIPTION
Implemented the Mean Squared Error (MSEv evaluation criterion) of the contribution function v(s) as proposed by [Frye et al. (2019)](https://arxiv.org/pdf/2006.01272.pdf) and used by [Olsen et al. (2022)](https://www.jmlr.org/papers/volume23/21-1413/21-1413.pdf).

This evaluation criterion is computed for all approaches as long as `internal$parameters$output_size == 1`.

Have also added plot functions and included a section in the vignette.