### PR TITLE
Fixed bug in get_default_n_batches function where shapr sets the numb…

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -693,15 +693,13 @@ get_default_n_batches <- function(approach, n_combinations) {
     suggestion <- ceiling(n_combinations / 10)
     this_min <- 10
     this_max <- 1000
-    min_checked <- max(c(this_min, suggestion))
-    ret <- min(c(this_max, min_checked))
   } else {
     suggestion <- ceiling(n_combinations / 100)
     this_min <- 2
     this_max <- 100
-    min_checked <- max(c(this_min, suggestion))
-    ret <- min(c(this_max, min_checked))
   }
+  min_checked <- max(c(this_min, suggestion))
+  ret <- min(c(this_max, min_checked, n_combinations - 1))
   message(
     paste0(
       "Setting parameter 'n_batches' to ", ret, " as a fair trade-off between memory consumption and ",

--- a/R/setup.R
+++ b/R/setup.R
@@ -217,7 +217,7 @@ check_n_batches <- function(internal) {
 
   if (n_batches >= actual_n_combinations) {
     stop(paste0(
-      "`n_batches` (", n_batches, ") must be smaller than the number feature combinations/`n_combinations` (",
+      "`n_batches` (", n_batches, ") must be smaller than the number of feature combinations/`n_combinations` (",
       actual_n_combinations, ")"
     ))
   }


### PR DESCRIPTION
…er of batches (when not provided in the explain function call) to a number which then throws an error in the check_n_batches function. Logical error as get_default_n_batches could previously set n_batches to a larger value than n_combinations - 1. Subtract one as the check_n_batches function specifies that n_batches must be strictly less than n_combinations.

The bug occurred for example for:
```
# The other stuff here is the variables from the first code block in the vignette.
> explanation <- explain(
+   model = model,
+   x_explain = x_explain,
+   x_train = x_train,
+   approach = "gaussian",
+   prediction_zero = p0,
+   n_combinations = 8
+ )
Note: Feature classes extracted from the model contains NA.
Assuming feature classes from the data are correct.

Setting parameter 'n_batches' to 10 as a fair trade-off between memory consumption and computation time.
Reducing 'n_batches' typically reduces the computation time at the cost of increased memory consumption.

Error in check_n_batches(internal) : 
  `n_batches` (10) must be smaller than the number of feature combinations/`n_combinations` (8)
```