### PR TITLE
Fixed bug. All messages says "n_combinations is larger than or equal …

### DIFF
--- a/R/setup_computation.R
+++ b/R/setup_computation.R
@@ -103,7 +103,7 @@ shapley_setup_forecast <- function(internal) {
   #### Updating parameters ####
 
   # Updating parameters$exact as done in feature_combinations
-  if (!exact && n_combinations > 2^n_features0) {
+  if (!exact && n_combinations >= 2^n_features0) {
     internal$parameters$exact <- TRUE # Note that this is exact only if all horizons use the exact method.
   }
 
@@ -161,7 +161,7 @@ shapley_setup <- function(internal) {
   #### Updating parameters ####
 
   # Updating parameters$exact as done in feature_combinations
-  if (!exact && n_combinations > 2^n_features0) {
+  if (!exact && n_combinations >= 2^n_features0) {
     internal$parameters$exact <- TRUE
   }
 
@@ -253,7 +253,7 @@ feature_combinations <- function(m, exact = TRUE, n_combinations = 200, weight_z
   if (!exact) {
     if (m_group == 0) {
       # Switch to exact for feature-wise method
-      if (n_combinations > 2^m) {
+      if (n_combinations >= 2^m) {
         n_combinations <- 2^m
         exact <- TRUE
         message(
@@ -266,7 +266,7 @@ feature_combinations <- function(m, exact = TRUE, n_combinations = 200, weight_z
       }
     } else {
       # Switch to exact for feature-wise method
-      if (n_combinations > (2^m_group)) {
+      if (n_combinations >= (2^m_group)) {
         n_combinations <- 2^m_group
         exact <- TRUE
         message(

--- a/inst/scripts/devel/testing_n_cobinations_equal_2_power_m.R
+++ b/inst/scripts/devel/testing_n_cobinations_equal_2_power_m.R
@@ -1,0 +1,71 @@
+# In this code we demonstrate that (before the bugfix) the `explain()` function
+# does not enter the exact mode when n_combinations is larger than or equal to 2^m.
+# The mode is only changed if n_combinations is strictly larger than 2^m.
+# This means that we end up with using all coalitions when n_combinations is 2^m,
+# but use not the exact Shapley kernel weights.
+# Bugfix replaces `>` with `=>`in the places where the code tests if
+# n_combinations is larger than or equal to 2^m. Then the text/messages printed by
+# shapr and the code correspond.
+
+library(xgboost)
+library(data.table)
+
+data("airquality")
+data <- data.table::as.data.table(airquality)
+data <- data[complete.cases(data), ]
+
+x_var <- c("Solar.R", "Wind", "Temp", "Month")
+y_var <- "Ozone"
+
+ind_x_explain <- 1:6
+x_train <- data[-ind_x_explain, ..x_var]
+y_train <- data[-ind_x_explain, get(y_var)]
+x_explain <- data[ind_x_explain, ..x_var]
+
+# Fitting a basic xgboost model to the training data
+model <- xgboost::xgboost(
+  data = as.matrix(x_train),
+  label = y_train,
+  nround = 20,
+  verbose = FALSE
+)
+
+# Specifying the phi_0, i.e. the expected prediction without any features
+p0 <- mean(y_train)
+
+# Computing the conditional Shapley values using the gaussian approach
+explanation_exact <- explain(
+  model = model,
+  x_explain = x_explain,
+  x_train = x_train,
+  n_samples = 2, # Low value for fast computations
+  n_batches = 1, # Not related to the bug
+  approach = "gaussian",
+  prediction_zero = p0,
+  n_combinations = NULL
+)
+
+# Computing the conditional Shapley values using the gaussian approach
+explanation_should_also_be_exact <- explain(
+  model = model,
+  x_explain = x_explain,
+  x_train = x_train,
+  n_samples = 2, # Low value for fast computations
+  n_batches = 1, # Not related to the bug
+  approach = "gaussian",
+  prediction_zero = p0,
+  n_combinations = 2^ncol(x_explain)
+)
+
+# see that both `explain()` objects have the same number of combinations
+explanation_exact$internal$parameters$n_combinations
+explanation_should_also_be_exact$internal$parameters$n_combinations
+
+# But the first one of them is exact and the other not.
+explanation_exact$internal$parameters$exact
+explanation_should_also_be_exact$internal$parameters$exact
+
+# Can also see that the Shapley weights differ, as the first one uses
+# the correct values, while the other one uses the sampling frequency.
+explanation_exact$internal$objects$X$shapley_weight
+explanation_should_also_be_exact$internal$objects$X$shapley_weight

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1345,6 +1345,105 @@ test_that("Error with too low `n_combinations`", {
   )
 })
 
+test_that("Shapr with `n_combinations` >= 2^m uses exact Shapley kernel weights", {
+  # Check that the `explain()` function enters the exact mode when n_combinations
+  # is larger than or equal to 2^m.
+
+  # Create three explainer object: one with exact mode, one with
+  # `n_combinations` = 2^m, and one with `n_combinations` > 2^m
+  expect_no_message(
+    object = {
+      explanation_exact = explain(
+        model = model_lm_numeric,
+        x_explain = x_explain_numeric,
+        x_train = x_train_numeric,
+        approach = "gaussian",
+        prediction_zero = p0,
+        n_samples = 2, # Low value for fast computations
+        n_batches = 1, # Not related to the bug
+        seed = 123,
+        n_combinations = NULL
+      )
+    }
+  )
+
+  # We should get a message saying that we are using the exact mode.
+  # The `regexp` format match the one written in `feature_combinations()`.
+  expect_message(
+    object = {
+      explanation_equal = explain(
+        model = model_lm_numeric,
+        x_explain = x_explain_numeric,
+        x_train = x_train_numeric,
+        approach = "gaussian",
+        prediction_zero = p0,
+        n_samples = 2, # Low value for fast computations
+        n_batches = 1, # Not related to the bug
+        seed = 123,
+        n_combinations = 2^ncol(x_explain_numeric))
+    },
+    regexp = "Success with message:\nn_combinations is larger than or equal to 2\\^m = 32. \nUsing exact instead.")
+
+  # We should get a message saying that we are using the exact mode.
+  # The `regexp` format match the one written in `feature_combinations()`.
+  expect_message(
+    object = {
+      explanation_larger = explain(
+        model = model_lm_numeric,
+        x_explain = x_explain_numeric,
+        x_train = x_train_numeric,
+        approach = "gaussian",
+        prediction_zero = p0,
+        n_samples = 2, # Low value for fast computations
+        n_batches = 1, # Not related to the bug
+        seed = 123,
+        n_combinations = 2^ncol(x_explain_numeric) + 1)
+    },
+    regexp = "Success with message:\nn_combinations is larger than or equal to 2\\^m = 32. \nUsing exact instead.")
+
+  # REMOVE THIS AFTER DISCUSSING WITH MARTIN.
+  # Note that the tests below are technically redundant if the test above have passed.
+  # I.e., we technically don't need to define `explanation_exact`, `explanation_equal`,
+  # and `explanation_larger`. Thus, we can remove those above and go from getting
+  # the nonconstructive error message "Error: `{ ... }` did not throw the expected message."
+  # to the error message "Error: `explain(...)` did not throw the expected message." by rather
+  # using:
+  #
+  # expect_message(
+  #   object = explain(
+  #       model = model_lm_numeric,
+  #       x_explain = x_explain_numeric,
+  #       x_train = x_train_numeric,
+  #       approach = "gaussian",
+  #       prediction_zero = p0,
+  #       n_samples = 2, # Low value for fast computations
+  #       n_batches = 1, # Not related to the bug
+  #       seed = 123,
+  #       n_combinations = 2^ncol(x_explain_numeric)),
+  #   regexp = "Success with message:\nn_combinations is larger than or equal to 2\\^m = 32. \nUsing exact instead.")
+  #
+  # However, the error message shall idealy not be shown, so not sure if this is important.
+  # Hear what Martin has to say.
+
+  # Test that they have the same number of combinations
+  expect_equal(explanation_exact$internal$parameters$n_combinations,
+               explanation_equal$internal$parameters$n_combinations)
+  expect_equal(explanation_exact$internal$parameters$n_combinations,
+               explanation_larger$internal$parameters$n_combinations)
+
+  # Test that all of them use the exact mode
+  expect_equal(explanation_exact$internal$parameters$exact,
+               explanation_equal$internal$parameters$exact)
+  expect_equal(explanation_exact$internal$parameters$exact,
+               explanation_larger$internal$parameters$exact)
+
+  # Test that they have the same Shapley kernel weights
+  expect_equal(explanation_exact$internal$objects$X$shapley_weight,
+               explanation_equal$internal$objects$X$shapley_weight)
+  expect_equal(explanation_exact$internal$objects$X$shapley_weight,
+               explanation_larger$internal$objects$X$shapley_weight)
+})
+
 test_that("Correct dimension of S when sampling combinations with groups", {
   n_combinations <- 5
 
@@ -1596,3 +1695,4 @@ test_that("gaussian approach use the user provided parameters", {
     gaussian.provided_cov_mat
   )
 })
+

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1353,7 +1353,7 @@ test_that("Shapr with `n_combinations` >= 2^m uses exact Shapley kernel weights"
   # `n_combinations` = 2^m, and one with `n_combinations` > 2^m
   expect_no_message(
     object = {
-      explanation_exact = explain(
+      explanation_exact <- explain(
         model = model_lm_numeric,
         x_explain = x_explain_numeric,
         x_train = x_train_numeric,
@@ -1371,7 +1371,7 @@ test_that("Shapr with `n_combinations` >= 2^m uses exact Shapley kernel weights"
   # The `regexp` format match the one written in `feature_combinations()`.
   expect_message(
     object = {
-      explanation_equal = explain(
+      explanation_equal <- explain(
         model = model_lm_numeric,
         x_explain = x_explain_numeric,
         x_train = x_train_numeric,
@@ -1380,15 +1380,17 @@ test_that("Shapr with `n_combinations` >= 2^m uses exact Shapley kernel weights"
         n_samples = 2, # Low value for fast computations
         n_batches = 1, # Not related to the bug
         seed = 123,
-        n_combinations = 2^ncol(x_explain_numeric))
+        n_combinations = 2^ncol(x_explain_numeric)
+      )
     },
-    regexp = "Success with message:\nn_combinations is larger than or equal to 2\\^m = 32. \nUsing exact instead.")
+    regexp = "Success with message:\nn_combinations is larger than or equal to 2\\^m = 32. \nUsing exact instead."
+  )
 
   # We should get a message saying that we are using the exact mode.
   # The `regexp` format match the one written in `feature_combinations()`.
   expect_message(
     object = {
-      explanation_larger = explain(
+      explanation_larger <- explain(
         model = model_lm_numeric,
         x_explain = x_explain_numeric,
         x_train = x_train_numeric,
@@ -1397,9 +1399,11 @@ test_that("Shapr with `n_combinations` >= 2^m uses exact Shapley kernel weights"
         n_samples = 2, # Low value for fast computations
         n_batches = 1, # Not related to the bug
         seed = 123,
-        n_combinations = 2^ncol(x_explain_numeric) + 1)
+        n_combinations = 2^ncol(x_explain_numeric) + 1
+      )
     },
-    regexp = "Success with message:\nn_combinations is larger than or equal to 2\\^m = 32. \nUsing exact instead.")
+    regexp = "Success with message:\nn_combinations is larger than or equal to 2\\^m = 32. \nUsing exact instead."
+  )
 
   # REMOVE THIS AFTER DISCUSSING WITH MARTIN.
   # Note that the tests below are technically redundant if the test above have passed.
@@ -1426,22 +1430,34 @@ test_that("Shapr with `n_combinations` >= 2^m uses exact Shapley kernel weights"
   # Hear what Martin has to say.
 
   # Test that they have the same number of combinations
-  expect_equal(explanation_exact$internal$parameters$n_combinations,
-               explanation_equal$internal$parameters$n_combinations)
-  expect_equal(explanation_exact$internal$parameters$n_combinations,
-               explanation_larger$internal$parameters$n_combinations)
+  expect_equal(
+    explanation_exact$internal$parameters$n_combinations,
+    explanation_equal$internal$parameters$n_combinations
+  )
+  expect_equal(
+    explanation_exact$internal$parameters$n_combinations,
+    explanation_larger$internal$parameters$n_combinations
+  )
 
   # Test that all of them use the exact mode
-  expect_equal(explanation_exact$internal$parameters$exact,
-               explanation_equal$internal$parameters$exact)
-  expect_equal(explanation_exact$internal$parameters$exact,
-               explanation_larger$internal$parameters$exact)
+  expect_equal(
+    explanation_exact$internal$parameters$exact,
+    explanation_equal$internal$parameters$exact
+  )
+  expect_equal(
+    explanation_exact$internal$parameters$exact,
+    explanation_larger$internal$parameters$exact
+  )
 
   # Test that they have the same Shapley kernel weights
-  expect_equal(explanation_exact$internal$objects$X$shapley_weight,
-               explanation_equal$internal$objects$X$shapley_weight)
-  expect_equal(explanation_exact$internal$objects$X$shapley_weight,
-               explanation_larger$internal$objects$X$shapley_weight)
+  expect_equal(
+    explanation_exact$internal$objects$X$shapley_weight,
+    explanation_equal$internal$objects$X$shapley_weight
+  )
+  expect_equal(
+    explanation_exact$internal$objects$X$shapley_weight,
+    explanation_larger$internal$objects$X$shapley_weight
+  )
 })
 
 test_that("Correct dimension of S when sampling combinations with groups", {
@@ -1695,4 +1711,3 @@ test_that("gaussian approach use the user provided parameters", {
     gaussian.provided_cov_mat
   )
 })
-


### PR DESCRIPTION
…to 2^m", but all the test only tested for "larger than". I.e., if the user specified n_combinations = 2^m in the call to shapr::explain, the function would not treat it as exact.

In the example below (the other stuff are the models and data from the vignette), we see that Shapley weights are sampled and that we are not using the exact version even though we use all of the coalitions.
```
> explanation <- explain(
+     model = model,
+     x_explain = x_explain,
+     x_train = x_train,
+     approach = "gaussian",
+     prediction_zero = p0,
+     n_combinations = 16
+ )
Note: Feature classes extracted from the model contains NA.
Assuming feature classes from the data are correct.

Setting parameter 'n_batches' to 10 as a fair trade-off between memory consumption and computation time.
Reducing 'n_batches' typically reduces the computation time at the cost of increased memory consumption.

> explanation$internal$objects$X$shapley_weight
 [1] 1000000       4       4       2       3       3       5       1       3       1       1       7       4       4       6 1000000
```