### PR TITLE
Change ubuntu runner for GHA

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,3 +1,8 @@
+# 01.09.23: Moved from ubuntu-latest to ubuntu-20.04 to avoid actions being cancelled
+# This is potentially due to CPU quota being exceeded as suggested
+# here: https://github.com/actions/runner-images/issues/6680 and
+# here: https://github.com/actions/runner-images/discussions/7188)
+
 # July 5th, 2022: This is a modifided version of the 'check-standard' version from
 # https://github.com/r-lib/actions/tree/v2/examples#standard-ci-workflow
 
@@ -7,6 +12,7 @@
 # 2. Runs on oldrel-2 as well
 # 3. R CMD check is performed WITHOUT the default as-cran flag. This allows snapshots to run without setting
 #    as-cran=TRUE in every single call to expect_snapshot
+
 
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
@@ -31,10 +37,10 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: 'oldrel-2'}
+          - {os: ubuntu-20.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-20.04,   r: 'release'}
+          - {os: ubuntu-20.04,   r: 'oldrel-1'}
+          - {os: ubuntu-20.04,   r: 'oldrel-2'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -1,3 +1,9 @@
+# 01.09.23: Moved from ubuntu-latest to ubuntu-20.04 to avoid actions being cancelled
+# This is potentially due to CPU quota being exceeded as suggested
+# here: https://github.com/actions/runner-images/issues/6680 and
+# here: https://github.com/actions/runner-images/discussions/7188)
+
+
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
@@ -8,7 +14,7 @@ name: lint-changed-files
 
 jobs:
   lint-changed-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,9 @@
+# 01.09.23: Moved from ubuntu-latest to ubuntu-20.04 to avoid actions being cancelled
+# This is potentially due to CPU quota being exceeded as suggested
+# here: https://github.com/actions/runner-images/issues/6680 and
+# here: https://github.com/actions/runner-images/discussions/7188)
+
+
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ name: lint
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,3 +1,9 @@
+# 01.09.23: Moved from ubuntu-latest to ubuntu-20.04 to avoid actions being cancelled
+# This is potentially due to CPU quota being exceeded as suggested
+# here: https://github.com/actions/runner-images/issues/6680 and
+# here: https://github.com/actions/runner-images/discussions/7188)
+
+
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
@@ -13,7 +19,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,3 +1,9 @@
+# 01.09.23: Moved from ubuntu-latest to ubuntu-20.04 to avoid actions being cancelled
+# This is potentially due to CPU quota being exceeded as suggested
+# here: https://github.com/actions/runner-images/issues/6680 and
+# here: https://github.com/actions/runner-images/discussions/7188)
+
+
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
@@ -10,7 +16,7 @@ jobs:
   document:
     if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document') }}
     name: document
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -1,3 +1,9 @@
+# 01.09.23: Moved from ubuntu-latest to ubuntu-20.04 to avoid actions being cancelled
+# This is potentially due to CPU quota being exceeded as suggested
+# here: https://github.com/actions/runner-images/issues/6680 and
+# here: https://github.com/actions/runner-images/discussions/7188)
+
+
 name: Remove old artifacts
 
 on:
@@ -7,7 +13,7 @@ on:
 
 jobs:
   remove-old-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
 
     steps:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# shapr (development version)
+# shapr (development version) 
 
 * Release a Python wrapper (`shaprpyr`, [#325](https://github.com/NorskRegnesentral/shapr/pull/325)) for explaining predictions from Python models (from Python) utilizing almost all functionality of `shapr`. The wrapper moves back and forth back and forth between Python and R, doing the prediction in Python, and almost everything else in R. This simplifies maintenance of `shaprpy` significantly. The wrapper is available [here](https://github.com/NorskRegnesentral/shapr/tree/master/python).
 * Complete restructuring motivated by introducing the Python wrapper. The restructuring splits the explanation tasks into smaller pieces, which was necessary to allow the Python wrapper to move back and forth between R and Python.


### PR DESCRIPTION
Apparently the cancelled actions on ubuntu-latest is caused by CPU quota being exceeded as suggested here: https://github.com/actions/runner-images/issues/6680 and here: https://github.com/actions/runner-images/discussions/7188

Works around this by moving from ubuntu-latest (which currently is ubuntu-22.04) to ubuntu-20.04. 

BUT, we need to be much more restrictive on the checks. Perhaps, changing back to only allowing this for admin (?)