### PR TITLE
Fix typo/bug in `xgboost_model.R`

### DIFF
--- a/R/model_xgboost.R
+++ b/R/model_xgboost.R
@@ -1,7 +1,7 @@
 #' @rdname predict_model
 #' @export
 predict_model.xgb.Booster <- function(x, newdata, ...) {
-  if (!requireNamespace("stats", quietly = TRUE)) {
+  if (!requireNamespace("xgboost", quietly = TRUE)) {
     stop("The xgboost package is required for predicting xgboost models")
   }
 


### PR DESCRIPTION
In this PR, we fix the code such that we check that the `xgboost` namespace is available.

In the previous version, `shapr` stoped running if `!requireNamespace("stat", quietly = TRUE)`, but this has been fixed to `!requireNamespace("xgboost", quietly = TRUE)`. That is, we now check for the right package.