### PR TITLE
Fix bug in vaeac related to updating of factor labels

### DIFF
--- a/R/approach_vaeac.R
+++ b/R/approach_vaeac.R
@@ -1887,14 +1887,13 @@ vaeac_get_save_file_names <- function(model_description,
 #' @param vaeac_model A `vaeac` model created using [vaeac()].
 #' @param optimizer_name String containing the name of the [torch::optimizer()] to use.
 #'
-#' @return Array of string containing the save files to use when training the `vaeac` model. The first three names
-#' corresponds to the best, best_running, and last epochs, in that order.
+#' @return A [torch::optim_adam()] optimizer connected to the parameters of the `vaeac_model`.
 #'
 #' @keywords internal
 #' @author Lars Henry Berge Olsen
 vaeac_get_optimizer <- function(vaeac_model, lr, optimizer_name = "adam") {
   if (optimizer_name == "adam") {
-    # Create the adam optimizer
+    # Create the adam optimizer with defualt parameters except from the provided learning rate
     optimizer <- torch::optim_adam(
       params = vaeac_model$parameters,
       lr = lr,

--- a/R/approach_vaeac.R
+++ b/R/approach_vaeac.R
@@ -2831,7 +2831,7 @@ vaeac_plot_imputed_ggpairs <- function(
     seed = explanation$internal$parameters$seed
   )
 
-  # Combine the true (if there are any) adn imputed data and ensure that the categorical features are marked as factors.
+  # Combine the true (if there are any) and imputed data and ensure that the categorical features are marked as factors.
   combined_data <- data.table(rbind(x_true, imputed_values))
   col_cat_names <- checkpoint$col_cat_names
   if (length(col_cat_names) > 0) combined_data[, (col_cat_names) := lapply(.SD, as.factor), .SDcols = col_cat_names]

--- a/R/approach_vaeac_torch_modules.R
+++ b/R/approach_vaeac_torch_modules.R
@@ -981,8 +981,13 @@ vaeac_postprocess_data <- function(data, vaeac_model_state_list) {
   # Convert all categorical features (if there are any) from numeric back to factors with the original class names
   if (length(col_cat_names) > 0) {
     lapply(col_cat_names, function(col_cat_name) {
-      data[, (col_cat_name) := lapply(.SD, factor, labels = map_new_to_original_names[[col_cat_name]]),
-        .SDcols = col_cat_name
+      data[, (col_cat_name) := lapply(
+        .SD,
+        factor,
+        labels = map_new_to_original_names[[col_cat_name]],
+        levels = seq_along(map_new_to_original_names[[col_cat_name]])
+      ),
+      .SDcols = col_cat_name
       ]
     })
   }

--- a/man/vaeac_get_optimizer.Rd
+++ b/man/vaeac_get_optimizer.Rd
@@ -14,8 +14,7 @@ vaeac_get_optimizer(vaeac_model, lr, optimizer_name = "adam")
 \item{optimizer_name}{String containing the name of the \code{\link[torch:optimizer]{torch::optimizer()}} to use.}
 }
 \value{
-Array of string containing the save files to use when training the \code{vaeac} model. The first three names
-corresponds to the best, best_running, and last epochs, in that order.
+A \code{\link[torch:optim_adam]{torch::optim_adam()}} optimizer connected to the parameters of the \code{vaeac_model}.
 }
 \description{
 Only \code{\link[torch:optim_adam]{torch::optim_adam()}} is currently supported. But it is easy to add an additional option later.


### PR DESCRIPTION
In this pull request, we fix a bug in the `VAEAC` approach that could occur for specific batches of combinations. 
The bug happened when vaeac converted the imputed integers back to the original factors, and not all possible levels were present. We have fixed the bug by specifying `levels = ...` in the call to the `factor(...)` function. This bug never occurred when `n_batches = 1` and was not likely to occur for low values of `n_batches`.  It was more likely to occur for rare levels.
