### PR TITLE
Update the manuals

### DIFF
--- a/R/explain.R
+++ b/R/explain.R
@@ -97,14 +97,14 @@
 #'
 #' @param ... Further arguments passed to specific approaches
 #'
-#' @inheritDotParams setup_approach.empirical
-#' @inheritDotParams setup_approach.independence
-#' @inheritDotParams setup_approach.gaussian
-#' @inheritDotParams setup_approach.copula
-#' @inheritDotParams setup_approach.ctree
-#' @inheritDotParams setup_approach.vaeac
-#' @inheritDotParams setup_approach.categorical
-#' @inheritDotParams setup_approach.timeseries
+#' @inheritDotParams setup_approach.empirical -internal
+#' @inheritDotParams setup_approach.independence -internal
+#' @inheritDotParams setup_approach.gaussian -internal
+#' @inheritDotParams setup_approach.copula -internal
+#' @inheritDotParams setup_approach.ctree -internal
+#' @inheritDotParams setup_approach.vaeac -internal
+#' @inheritDotParams setup_approach.categorical -internal
+#' @inheritDotParams setup_approach.timeseries -internal
 #'
 #' @details The most important thing to notice is that `shapr` has implemented six different
 #' approaches for estimating the conditional distributions of the data, namely `"empirical"`,

--- a/man/explain.Rd
+++ b/man/explain.Rd
@@ -144,7 +144,6 @@ Only used for \code{empirical.type} is either \code{"AICc_each_k"} or \code{"AIC
     \item{\code{empirical.cov_mat}}{Numeric matrix. (Optional, default = NULL)
 Containing the covariance matrix of the data generating distribution used to define the Mahalanobis distance.
 \code{NULL} means it is estimated from \code{x_train}.}
-    \item{\code{internal}}{Not used.}
     \item{\code{gaussian.mu}}{Numeric vector. (Optional)
 Containing the mean of the data generating distribution.
 \code{NULL} means it is estimated from the \code{x_train}.}


### PR DESCRIPTION
In this PR, we fix several issues in the documentation:

1. Fixed such that `internal` no longer appears as an `...` argument to `explain()`.

Should not merge before also fixing that `?shapr::prepare_data` states that `internal` is not used because it is.