### PR TITLE
Skip vaeac tests on mac os

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,9 +19,9 @@
 
 on:
   push:
-    branches: [main, master, cranversion, devel]
+    branches: [main, master, cranversion, devel, 'shapr-1.0.0']
   pull_request:
-    branches: [main, master, cranversion, devel]
+    branches: [main, master, cranversion, devel, 'shapr-1.0.0']
 
 name: R-CMD-check
 

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -8,7 +8,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main, master, cranversion, devel, 'shapr-1.0.0']
 
 name: lint-changed-files
 

--- a/tests/testthat/test-regular-output.R
+++ b/tests/testthat/test-regular-output.R
@@ -346,6 +346,7 @@ test_that("output_lm_mixed_ctree", {
 })
 
 test_that("output_lm_mixed_vaeac", {
+  skip_on_os("mac") # The code runs on macOS, but it gives different Shapley values due to inconsistencies in torch seed
   expect_snapshot_rds(
     explain(
       testing = TRUE,

--- a/tests/testthat/test-regular-output.R
+++ b/tests/testthat/test-regular-output.R
@@ -161,6 +161,7 @@ test_that("output_lm_numeric_ctree", {
 })
 
 test_that("output_lm_numeric_vaeac", {
+  skip_on_os("mac") # The code runs on macOS, but it gives different Shapley values due to inconsistencies in torch seed
   expect_snapshot_rds(
     explain(
       testing = TRUE,
@@ -198,6 +199,7 @@ test_that("output_lm_categorical_ctree", {
 })
 
 test_that("output_lm_categorical_vaeac", {
+  skip_on_os("mac") # The code runs on macOS, but it gives different Shapley values due to inconsistencies in torch seed
   expect_snapshot_rds(
     explain(
       testing = TRUE,


### PR DESCRIPTION
All `vaeac` code run, but give different output due to seed inconsistency in `torch`. Skipping the tests make RCMDcheck pass on macOS as well.
