### PR TITLE
Adjust requirements for testing ++

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,6 @@ Suggests:
     forecast,
     torch,
     GGally,
-    progress,
     coro,
     parsnip,
     recipes,

--- a/R/model_arima.R
+++ b/R/model_arima.R
@@ -2,8 +2,8 @@
 #' @inheritParams explain_forecast
 #' @export
 predict_model.Arima <- function(x, newdata, newreg, horizon, explain_idx, explain_lags, y, xreg, ...) {
-  if (!requireNamespace("stats", quietly = TRUE)) {
-    stop("The stats package is required for predicting stats models")
+  if (!requireNamespace("forecast", quietly = TRUE)) {
+    stop("The forecast package is required when explaining Arima models")
   }
 
   prediction <- matrix(NA, length(explain_idx), horizon)

--- a/tests/testthat/helper-ar-arima.R
+++ b/tests/testthat/helper-ar-arima.R
@@ -15,4 +15,9 @@ model_arima_temp2 <- arima(data_arima$Temp[1:150], c(2, 1, 0), xreg = data_arima
 model_arima_temp_noxreg <- arima(data_arima$Temp[1:150], c(2, 1, 0))
 
 # When loading this here we avoid the "Registered S3 method overwritten" when calling forecast
-model_forecast_ARIMA_temp <- forecast::Arima(data_arima$Temp[1:150], order = c(2, 1, 0), xreg = data_arima$Wind[1:150])
+if (!requireNamespace("forecast", quietly = TRUE)) {
+  warning("The forecast package is required for testing explain_forecast()")
+} else {
+  model_forecast_ARIMA_temp <- forecast::Arima(data_arima$Temp[1:150], order = c(2, 1, 0), xreg = data_arima$Wind[1:150])
+}
+

--- a/tests/testthat/helper-ar-arima.R
+++ b/tests/testthat/helper-ar-arima.R
@@ -18,6 +18,9 @@ model_arima_temp_noxreg <- arima(data_arima$Temp[1:150], c(2, 1, 0))
 if (!requireNamespace("forecast", quietly = TRUE)) {
   warning("The forecast package is required for testing explain_forecast()")
 } else {
-  model_forecast_ARIMA_temp <- forecast::Arima(data_arima$Temp[1:150], order = c(2, 1, 0), xreg = data_arima$Wind[1:150])
+  model_forecast_ARIMA_temp <- forecast::Arima(
+    data_arima$Temp[1:150],
+    order = c(2, 1, 0),
+    xreg = data_arima$Wind[1:150]
+  )
 }
-

--- a/tests/testthat/test-forecast-output.R
+++ b/tests/testthat/test-forecast-output.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("forecast")
+
 test_that("forecast_output_ar_numeric", {
   expect_snapshot_rds(
     explain_forecast(

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("ggplot2")
+
 set.seed(123) #
 
 explain_mixed <- explain(


### PR DESCRIPTION
This pull request includes changes to improve package dependencies and testing robustness, particularly focusing on the `forecast` package. The most important changes include modifying package dependencies, updating model prediction requirements, and enhancing test cases to handle missing packages gracefully.

Package dependency updates:

* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL58): Removed `progress` from the `Suggests:` section.

Model prediction requirements:

* [`R/model_arima.R`](diffhunk://#diff-cc5de75da9e64cec0eb17d21efc22bfa81c0819952f2dcf0402294c5619972deL5-R6): Changed the required package for predicting `Arima` models from `stats` to `forecast`.

Test enhancements:

* [`tests/testthat/test-plot.R`](diffhunk://#diff-959b6165e232f23473175b830385b022f63b82c61d2b5b5b977047fcd68bb8a3R1-R2): Added a `skip_if_not_installed("ggplot2")` check to skip tests if the `ggplot2` package is not installed. ++

Fixes #441 