### PR TITLE
Fix such that shapr objects print the data.table when called.

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -10,6 +10,6 @@ print.shapr <- function(x, digits = 4, ...) {
   shap <- copy(x$shapley_values_est)
   shap_names <- x$internal$parameters$shap_names
   cols <- c("none", shap_names)
-  shap[, (cols) := lapply(.SD, round, digits = digits + 2), .SDcols = cols]
+  shap[, (cols) := lapply(.SD, round, digits = digits + 2), .SDcols = cols][]
   print(shap, digits = digits)
 }


### PR DESCRIPTION
In this PR, we fix a bug related to the output of `explain()`, i.e., the `"shapr"` type list, not printing anything when called. See the example below. 

This is caused by print.shapr() updating a data.table by reference inside a function, and then there is a know bug in `data.table` that said data.table will not be printed. See https://cran.r-project.org/web/packages/data.table/vignettes/datatable-faq.html#sec:why-do-i-have-to-type-dt-sometimes-twice-after-using-to-print-the-result-to-console and https://stackoverflow.com/questions/32988099/data-table-objects-assigned-with-from-within-function-not-printed for explanation. The easy solution is to add `[]` at the end of the update-by-reference code line. 

```
# Load example data and fit model
data("airquality")
airquality <- airquality[complete.cases(airquality), ]
x_var <- c("Solar.R", "Wind", "Temp", "Month")
y_var <- "Ozone"
data_train <- head(airquality, -3)
data_explain <- tail(airquality, 3)
x_train <- data_train[, x_var]
x_explain <- data_explain[, x_var]
lm_formula <- as.formula(paste0(y_var, " ~ ", paste0(x_var, collapse = " + ")))
model <- lm(lm_formula, data = data_train)
p <- mean(data_train[, y_var])

# Explain model
explain1 <- explain(
  model = model,
  x_explain = x_explain,
  x_train = x_train,
  approach = "empirical",
  phi0 = p,
  n_MC_samples = 1e2
)

# Print the Shapley values
explain1 # THIS DID PREVIOUSLY NOT PRINT ANYTHING
```

TODO:

- [ ] Why do we even update the data.table? I do not see why it is needed. Discuss with @martinju.
- [ ] Check if we need to update any vignettes or documentation.