### PR TITLE
* Disable computation of standard deviation if exact is selected due to "initial_n_coalitions was set to be equal to or larger than n_shapley_values^2"

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -1583,6 +1583,7 @@ set_iterative_parameters <- function(internal, prev_iter_list = NULL) {
   # Update exact if initial_n_coalitions was set to be equal to or larger than n_shapley_values^2
   if (iterative_args$initial_n_coalitions >= internal$parameters$n_shapley_values^2) {
     internal$parameters$exact <- TRUE
+    internal$parameters$extra_computation_args$compute_sd <- FALSE
   }
 
   check_iterative_args(iterative_args)


### PR DESCRIPTION
Repro:
```
source("tests/testthat/helper-ar-arima.R")
 res <- explain_forecast(
      testing = TRUE,
      model = model_arima_temp2,
      y = data_arima[1:150, "Temp"],
      xreg = data_arima[, c("Wind", "Solar.R", "Ozone")],
      train_idx = 3:148,
      explain_idx = 149:150,
      explain_y_lags = 3,
      explain_xreg_lags = c(3, 3, 3),
      horizon = 3,
      approach = "empirical",
      phi0 = p0_ar,
      seed = 1,
      group_lags = TRUE,
      max_n_coalitions = 150,
      iterative = TRUE,
      exact = TRUE,
      iterative_args = list(initial_n_coalitions = 16, convergence_tol = 7e-3)
    )
```