### PR TITLE
remove as.integer

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -639,7 +639,7 @@ check_and_set_parameters <- function(internal, type) {
       internal$objects$dt_valid_causal_coalitions[, .N, by = .(coalition_size)][-c(1, .N), N]
   } else {
     # Do not set it for forecast, as it is generated on the fly as the value of changes with the horizon
-    if (type != "forecast") internal$parameters$n_coal_each_size <- as.integer(choose(m, seq(m - 1)))
+    if (type != "forecast") internal$parameters$n_coal_each_size <- choose(m, seq(m - 1))
   }
 
   # Adjust max_n_coalitions


### PR DESCRIPTION
This pull request includes a minor change to the `check_and_set_parameters` function in `R/setup.R`. The change removes an unnecessary type conversion when setting the `n_coal_each_size` parameter, which causes an error when there are larger number of features since as.integer cannot convert values larger than 2*10^9. Everything works without as.integer.