### PR TITLE
Fix cli timing bug due to wrong environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 * Fixed handling of ordered factor features by treating them as factors in feature specifications and adding stricter checks for malformed feature specification lists. ([#495](https://github.com/NorskRegnesentral/shapr/pull/495))
+* Fixed `cli::cli_progress_step()` reporting artificially short timings for the v(S) computation step by passing `.envir = parent.frame()` to bind the progress bar's lifetime to the correct calling environment. ([#496](https://github.com/NorskRegnesentral/shapr/pull/496))
 
 ### Tests
 * Skip `vdiffr` plot snapshot tests on R < 4.5.0 to avoid spurious failures caused by formatting changes in older R versions. ([#494](https://github.com/NorskRegnesentral/shapr/pull/494))

--- a/R/cli.R
+++ b/R/cli.R
@@ -157,7 +157,7 @@ cli_compute_vS <- function(internal) {
   approach <- internal$parameters$approach
 
   if ("progress" %in% verbose) {
-    cli::cli_progress_step("Computing v(S)")
+    cli::cli_progress_step("Computing v(S)", .envir = parent.frame())
   }
   if ("vS_details" %in% verbose) {
     if ("regression_separate" %in% approach) {


### PR DESCRIPTION
Previously, there was a bug that `cli` printed out that `"Computing v(S) [8ms]"` only took a couple of ms independently off how long it actually took.

The logical error is that `cli::cli_progress_step` ties the progress bar's lifetime to the calling function's environment. Since it's called inside `cli_compute_vS()`, the step is marked "done" when `cli_compute_vS()` returns, which is before the actual `v(S)` computation runs. That's why it shows 8ms.

The fix is to pass `.envir = parent.frame()` to `cli::cli_progress_step` so the progress bar's lifetime is tied to `compute_vS()` instead of `cli_compute_vS()`.

The other `cli` calls happens inside the correct function environment.

Now we get a correct printout:
`v Computing v(S) [3.4s] `