### PR TITLE
Fix non-iterative exact-coalition fallback threshold (m^2 -> 2^m)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: shapr
-Version: 1.0.8.9002
+Version: 1.0.8.9003
 Title: Prediction Explanation with Dependence-Aware Shapley Values
 Description: Complex machine learning models are often hard to interpret. However, in
   many situations it is crucial to understand and explain why a model made a specific

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 * Added pre-PR workflow scripts (`dev/prepare-pr`, `dev/check-pr`, `dev/publish-pr`) with `dev/pr-workflow.md` for automated and agent-assisted PR readiness checks; consolidated development scripts under `dev/`. ([#494](https://github.com/NorskRegnesentral/shapr/pull/494))
 
 ### Bug fixes
-* Fixed a bug where non-iterative estimation (`iterative = FALSE`) with a moderate number of features could ignore `max_n_coalitions` and enumerate all `2^n_features` coalitions (an incorrect exact-computation threshold of `n_shapley_values^2` instead of `2^n_shapley_values`), causing severe slowdowns and `RcppArmadillo` `Cube::init()` failures in high dimensions. (branch: bugfix/exact-coalition-threshold)
+* Fixed a bug where non-iterative estimation (`iterative = FALSE`) with a moderate number of features could ignore `max_n_coalitions` and enumerate all `2^n_features` coalitions (an incorrect exact-computation threshold of `n_shapley_values^2` instead of `2^n_shapley_values`), causing severe slowdowns and `RcppArmadillo` `Cube::init()` failures in high dimensions. ([#505](https://github.com/NorskRegnesentral/shapr/pull/505))
 * Fixed handling of ordered factor features by treating them as factors in feature specifications and adding stricter checks for malformed feature specification lists. ([#495](https://github.com/NorskRegnesentral/shapr/pull/495))
 * Fixed `cli::cli_progress_step()` reporting artificially short timings for the v(S) computation step by passing `.envir = parent.frame()` to bind the progress bar's lifetime to the correct calling environment. ([#496](https://github.com/NorskRegnesentral/shapr/pull/496))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Added pre-PR workflow scripts (`dev/prepare-pr`, `dev/check-pr`, `dev/publish-pr`) with `dev/pr-workflow.md` for automated and agent-assisted PR readiness checks; consolidated development scripts under `dev/`. ([#494](https://github.com/NorskRegnesentral/shapr/pull/494))
 
 ### Bug fixes
+* Fixed a bug where non-iterative estimation (`iterative = FALSE`) with a moderate number of features silently ignored `max_n_coalitions` and enumerated all `2^n_features` coalitions. When deciding whether to switch to exact computation, `set_iterative_parameters()` compared `initial_n_coalitions` against `n_shapley_values^2` (`m^2`) instead of the correct `2^n_shapley_values` (`2^m`); for moderate `n_features` (roughly 6-25) this forced exact enumeration even when far fewer coalitions were requested, causing severe slowdowns and, in high dimensions, `RcppArmadillo` `Cube::init(): requested size is too large` failures. (branch: bugfix/exact-coalition-threshold)
 * Fixed handling of ordered factor features by treating them as factors in feature specifications and adding stricter checks for malformed feature specification lists. ([#495](https://github.com/NorskRegnesentral/shapr/pull/495))
 * Fixed `cli::cli_progress_step()` reporting artificially short timings for the v(S) computation step by passing `.envir = parent.frame()` to bind the progress bar's lifetime to the correct calling environment. ([#496](https://github.com/NorskRegnesentral/shapr/pull/496))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 [pyshapr CHANGELOG](https://norskregnesentral.github.io/shapr/py_changelog.html).
 
 
-# shapr 1.0.8.9002
+# shapr 1.0.8.9003
 
 ### New features
 * Added the `"arf"` approach for conditional sampling with adversarial random forests via the `arf` package ([#497](https://github.com/NorskRegnesentral/shapr/pull/497))
@@ -14,7 +14,7 @@
 * Added pre-PR workflow scripts (`dev/prepare-pr`, `dev/check-pr`, `dev/publish-pr`) with `dev/pr-workflow.md` for automated and agent-assisted PR readiness checks; consolidated development scripts under `dev/`. ([#494](https://github.com/NorskRegnesentral/shapr/pull/494))
 
 ### Bug fixes
-* Fixed a bug where non-iterative estimation (`iterative = FALSE`) with a moderate number of features silently ignored `max_n_coalitions` and enumerated all `2^n_features` coalitions. When deciding whether to switch to exact computation, `set_iterative_parameters()` compared `initial_n_coalitions` against `n_shapley_values^2` (`m^2`) instead of the correct `2^n_shapley_values` (`2^m`); for moderate `n_features` (roughly 6-25) this forced exact enumeration even when far fewer coalitions were requested, causing severe slowdowns and, in high dimensions, `RcppArmadillo` `Cube::init(): requested size is too large` failures. (branch: bugfix/exact-coalition-threshold)
+* Fixed a bug where non-iterative estimation (`iterative = FALSE`) with a moderate number of features could ignore `max_n_coalitions` and enumerate all `2^n_features` coalitions (an incorrect exact-computation threshold of `n_shapley_values^2` instead of `2^n_shapley_values`), causing severe slowdowns and `RcppArmadillo` `Cube::init()` failures in high dimensions. (branch: bugfix/exact-coalition-threshold)
 * Fixed handling of ordered factor features by treating them as factors in feature specifications and adding stricter checks for malformed feature specification lists. ([#495](https://github.com/NorskRegnesentral/shapr/pull/495))
 * Fixed `cli::cli_progress_step()` reporting artificially short timings for the v(S) computation step by passing `.envir = parent.frame()` to bind the progress bar's lifetime to the correct calling environment. ([#496](https://github.com/NorskRegnesentral/shapr/pull/496))
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -1770,8 +1770,8 @@ set_iterative_parameters <- function(internal, prev_iter_list = NULL) {
     iterative_args$initial_n_coalitions <- ceiling(iterative_args$initial_n_coalitions * 0.5) * 2
   }
 
-  # Update exact if initial_n_coalitions was set to be equal to or larger than n_shapley_values^2
-  if (iterative_args$initial_n_coalitions >= internal$parameters$n_shapley_values^2) {
+  # Update exact if initial_n_coalitions is at least the total number of coalitions (2^n_shapley_values)
+  if (iterative_args$initial_n_coalitions >= 2^internal$parameters$n_shapley_values) {
     internal$parameters$exact <- TRUE
     internal$parameters$extra_computation_args$compute_sd <- FALSE
   }

--- a/tests/testthat/test-iterative-setup.R
+++ b/tests/testthat/test-iterative-setup.R
@@ -26,6 +26,31 @@ test_that("iterative_args are respected", {
 })
 
 
+test_that("non-iterative estimation does not force exact for moderate n_features", {
+  # Regression test: set_iterative_parameters() previously flipped to exact when
+  # initial_n_coalitions >= n_shapley_values^2 (m^2) instead of the correct
+  # >= 2^n_shapley_values (2^m). With m = 5 features that wrongly forced exact
+  # (all 2^5 = 32 coalitions) whenever max_n_coalitions >= 25, even though fewer
+  # were requested. Here 25 <= 30 < 32, so the bug would enumerate all 32.
+  ex <- explain(
+    testing = TRUE,
+    model = model_lm_numeric,
+    x_explain = x_explain_numeric,
+    x_train = x_train_numeric,
+    approach = "gaussian",
+    phi0 = p0,
+    seed = 1,
+    max_n_coalitions = 30,
+    iterative = FALSE
+  )
+
+  # 30 < 2^5 = 32, so estimation must stay in sampling mode (not exact) and use
+  # at most the requested number of coalitions.
+  expect_false(ex$internal$parameters$exact)
+  expect_lte(ex$internal$iter_list[[length(ex$internal$iter_list)]]$X[, .N], 30)
+})
+
+
 test_that("iterative feature wise and groupwise computations identical", {
   groups <- list(
     Solar.R = "Solar.R",


### PR DESCRIPTION
## Summary

`set_iterative_parameters()` used the wrong threshold when deciding whether to switch a non-iterative run to exact computation. It compared `initial_n_coalitions` against `n_shapley_values^2` (m²) instead of `2^n_shapley_values` (2^m — the actual number of coalitions).

For a moderate number of features this silently forced exact enumeration of **all** `2^m` coalitions even when far fewer were requested. For example, with 20 features and `max_n_coalitions = 512, iterative = FALSE`, shapr enumerated all `2^20 = 1,048,576` coalitions (while its log misleadingly reported *"Using 512 of 1048576"*). This causes:

- severe slowdowns (seconds → hours), and
- `RcppArmadillo` `Cube::init(): requested size is too large` failures in high dimensions.

`iterative = TRUE` was unaffected, because its `initial_n_coalitions` starts small.

## Fix

One-line correction in `R/setup.R`, aligning with the `2^n_shapley_values` threshold used everywhere else in the codebase (e.g. `shapley_setup.R`, `prepare_next_iteration.R`, and the `max_n_coalitions` bounds in `setup.R`):

```r
- if (iterative_args$initial_n_coalitions >= internal$parameters$n_shapley_values^2) {
+ if (iterative_args$initial_n_coalitions >= 2^internal$parameters$n_shapley_values) {
```

## Verification

| n_features | max_n_coalitions | iterative | before | after |
|---|---|---|---|---|
| 20 | 512 | FALSE | 1,048,576 (2^20) | 512 |
| 12 | 512 | FALSE | 4,096 (2^12) | ≤ 512 |
| 30 | 512 | FALSE | 512 | 512 |

- Added a regression test in `tests/testthat/test-iterative-setup.R` (m = 5, `max_n_coalitions = 30, iterative = FALSE`: asserts sampling mode, not exact).
- Full snapshot-safe test suite: **545 passed, 0 failures, 0 snapshot changes**.
- `styler` / `lintr` clean.

## Provenance

Introduced in #449 ("Semi-deterministic sampling and asymmetric bugfix"); pre-existing and unrelated to the recent high-dimensional work in #504.
